### PR TITLE
feat: implement application routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "i18n_extract": "fedx-scripts formatjs extract --include=plugins",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "start": "fedx-scripts webpack-dev-server --progress",
-    "dev": "PUBLIC_PATH=/corporate-manager/ MFE_CONFIG_API_URL='http://local.edly.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.edly.io",
+    "dev": "PUBLIC_PATH=/corporate-manager MFE_CONFIG_API_URL='http://local.edly.io:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.edly.io",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests",
     "test:ci": "TZ=UTC fedx-scripts jest --silent --coverage --passWithNoTests",
     "types": "tsc --noEmit"

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,33 @@
-import { Route } from 'wouter';
-import CorpotatePartnerPage from './partner/CorporatePartnerPage';
+import { Route, Router as WouterRouter, Switch } from 'wouter';
 
-const Router = () => <Route component={CorpotatePartnerPage} />;
+import { getConfig } from '@edx/frontend-platform';
+import { lazy, Suspense } from 'react';
+import { paths } from '@src/constants';
+
+const CorporatePartnerPage = lazy(() => import('@src/partner/CorporatePartnerPage'));
+
+const Router = () => (
+  <Suspense fallback={<div>Loading...</div>}>
+    <WouterRouter base={getConfig().PUBLIC_PATH}>
+      <Switch>
+        <Route path={paths.partners.path} component={CorporatePartnerPage} />
+
+        <Route path={paths.catalogs.path}>
+          <h1>Catalogs</h1>
+        </Route>
+        <Route path={paths.courses.path}>
+          <h1>List of Courses</h1>
+        </Route>
+        <Route path={paths.courseDetail.path}>
+          <h1>Course Details</h1>
+        </Route>
+        <Route>
+          <h1>404 Not Found</h1>
+        </Route>
+      </Switch>
+    </WouterRouter>
+
+  </Suspense>
+);
 
 export default Router;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Centralized route definitions.
+ * Each route provides a path template and a builder for concrete URLs.
+ */
+export const paths = {
+  partners: {
+    path: '/',
+    buildPath: () => '/',
+  },
+
+  catalogs: {
+    path: '/catalogs/:partnerId/',
+    buildPath: (partnerId: string) => `/catalogs/${partnerId}/`,
+  },
+
+  courses: {
+    path: '/catalogs/:partnerId/courses',
+    buildPath: (partnerId: string) => `/catalogs/${partnerId}/courses`,
+  },
+
+  courseDetail: {
+    path: '/catalogs/:partnerId/courses/:courseId/',
+    buildPath: (partnerId: string, courseId: string) => `/catalogs/${partnerId}/courses/${courseId}/`,
+  },
+} as const;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,7 @@
+import { useLocation } from 'wouter';
+
+/**
+ * A custom hook that provides a navigation function.
+ * This function can be used to change the current route.
+ */
+export const useNavigate = () => useLocation()[1];

--- a/src/partner/components/CorporatePartnerList.tsx
+++ b/src/partner/components/CorporatePartnerList.tsx
@@ -5,8 +5,8 @@ import {
 } from '@openedx/paragon';
 
 import { CorporatePartner } from '@src/app/types';
-import { navigate } from 'wouter/use-browser-location';
 import TableName from '@src/app/TableName';
+import { useNavigate } from '@src/hooks';
 import { getPartners } from '../api';
 import TableFooter from '../../app/TableFooter';
 
@@ -22,6 +22,7 @@ type CellValue = {
 const tableActions = ['view'];
 
 const CorpotatePartnerList = () => {
+  const navigate = useNavigate();
   const intl = useIntl();
   const { data, isLoading } = useSuspenseQuery({
     queryKey: ['partners'],


### PR DESCRIPTION
This pull request introduces a new centralized routing system in the application. The main changes include refactoring the router to support multiple pages with lazy loading, defining all route paths in a single constants file, and adding a custom navigation hook. Additionally, the development script in `package.json` is slightly modified to fix the `PUBLIC_PATH`.

Routing system improvements:

* Refactored `Router.tsx` to use `wouter`'s `Router` and `Switch`, supporting multiple routes with lazy loading and a 404 fallback. The router now uses a base path from the config and displays placeholder components for catalog and course pages. (`src/Router.tsx`)
* Added a new `paths` object in `src/constants.ts` to centralize route definitions and provide path-building helpers for partner, catalog, course list, and course detail pages. (`src/constants.ts`)

Navigation enhancements:

* Introduced a custom `useNavigate` hook in `src/hooks.ts` to provide a simple navigation function using `wouter`. (`src/hooks.ts`)
* Updated `CorporatePartnerList.tsx` to use the new `useNavigate` hook instead of the previous `navigate` import. (`src/partner/components/CorporatePartnerList.tsx`) [[1]](diffhunk://#diff-62724cf220dd17557ac1d7290de509be6f7f3bee2544a9e6251b2cb244d495daL8-R9) [[2]](diffhunk://#diff-62724cf220dd17557ac1d7290de509be6f7f3bee2544a9e6251b2cb244d495daR25)

Development script fix:

* Fixed the `PUBLIC_PATH` in the `dev` script in `package.json` by removing the trailing slash for consistency with the new routing setup. (`package.json`)