### PR TITLE
Bc/add edit form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppProvider } from '@edx/frontend-platform/react';
 import Router from './Router';
+import { CatalogEditModalProvider } from './hooks/useCatalogFormModal';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,7 +14,9 @@ const queryClient = new QueryClient({
 const App = () => (
   <AppProvider wrapWithRouter={false}>
     <QueryClientProvider client={queryClient}>
-      <Router />
+      <CatalogEditModalProvider>
+        <Router />
+      </CatalogEditModalProvider>
     </QueryClientProvider>
   </AppProvider>
 );

--- a/src/app/CatalogEditForm.tsx
+++ b/src/app/CatalogEditForm.tsx
@@ -1,0 +1,71 @@
+import { getPartnerCatalogs } from '@src/catalogs/api';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import React, { FC } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import FormLayout from './FormLayout';
+import { FormElement } from './FormLayout/types';
+
+interface CatalogEditFormProps {
+  selectedCatalog: string | number | null;
+}
+
+const CATALOG_FORM_CONFIG: FormElement[] = [
+  { type: 'title', label: 'General Information' },
+  { name: 'isPublic', type: 'switch', label: 'Public Catalog' },
+  { name: 'name', type: 'text', label: 'Catalog Name' },
+  { name: 'homepage', type: 'text', label: 'Alternative Link' },
+  { name: 'supportEmail', type: 'email', label: 'Support Email' },
+  {
+    type: 'group',
+    fields: [
+      { name: 'startDate', type: 'date', label: 'Start Date' },
+      { name: 'endDate', type: 'date', label: 'End Date' },
+    ],
+  },
+  { type: 'divider' },
+
+  { type: 'title', label: 'Enrollment Settings' },
+  {
+    type: 'group',
+    fields: [
+      { name: 'enrollmentLimit', type: 'number', label: 'Course Enrollment Limit' },
+      { name: 'userLimit', type: 'number', label: 'User Limit' },
+    ],
+  },
+  {
+    type: 'group',
+    fields: [
+      { name: 'availableStartDate', type: 'date', label: 'Start Date' },
+      { name: 'availableEndDate', type: 'date', label: 'End Date' },
+    ],
+  },
+  { type: 'divider' },
+
+  { type: 'title', label: 'Advanced Settings' },
+  { name: 'emailDomainRegex', type: 'multiple-text', label: 'Partner Email Regex' },
+  { name: 'enableCustomCourses', type: 'switch', label: 'Enable Custom Courses' },
+  { name: 'isSelfEnrollment', type: 'switch', label: 'Self Enrollment' },
+];
+
+const CatalogEditForm: FC<CatalogEditFormProps> = ({ selectedCatalog }) => {
+  // TODO: Point to an endpoint that returns the catalog details
+  const { data: partnerCatalogs } = useSuspenseQuery({
+    queryKey: ['partnerCatalogs'],
+    queryFn: () => getPartnerCatalogs(),
+  });
+
+  const selectedCatalogData = partnerCatalogs.find(catalog => catalog.id === selectedCatalog);
+
+  const methods = useForm({
+    defaultValues: selectedCatalogData,
+    mode: 'onChange',
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <FormLayout form={CATALOG_FORM_CONFIG} />
+    </FormProvider>
+  );
+};
+
+export default CatalogEditForm;

--- a/src/app/FormLayout/FormField.tsx
+++ b/src/app/FormLayout/FormField.tsx
@@ -1,0 +1,59 @@
+import { Form } from '@openedx/paragon';
+import { FC } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { BaseFormField } from './types';
+
+const FormField: FC<BaseFormField> = ({
+  type, label, name, as, ...props
+}) => {
+  const { register, control } = useFormContext();
+
+  if (type === 'text' || type === 'number' || type === 'date' || type === 'email') {
+    return (
+      <Form.Group as={as} controlId={name}>
+        <Form.Label className="font-weight-bold">{label}</Form.Label>
+        <Form.Control id={name} {...register(name)} type={type} {...props} />
+      </Form.Group>
+    );
+  }
+
+  if (type === 'multiple-text') {
+    return (
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { value, onChange } }) => (
+          <Form.Group as={as} controlId={name}>
+            <Form.Label className="font-weight-bold">{label}</Form.Label>
+            <Form.Control
+              id={name}
+              type="text"
+              value={value}
+              onChange={(e) => onChange(e.target.value.split(',').map((v) => v.trim()))}
+              {...props}
+            />
+          </Form.Group>
+        )}
+      />
+    );
+  }
+
+  if (type === 'switch') {
+    return (
+      <Form.Group controlId={name} className="d-flex align-items-center">
+        <Form.Label className="mb-0 flex-grow-1 font-weight-bold">{label}</Form.Label>
+        <Form.Switch
+          {...register(name, {
+            onChange: (e) => e.target.checked,
+          })}
+          floatLabelLeft
+          {...props}
+        />
+      </Form.Group>
+    );
+  }
+
+  return null;
+};
+
+export default FormField;

--- a/src/app/FormLayout/index.tsx
+++ b/src/app/FormLayout/index.tsx
@@ -1,0 +1,36 @@
+import { Col, Form, Stack } from '@openedx/paragon';
+import { FC } from 'react';
+import { BaseFormField, FormElement } from './types';
+import FormField from './FormField';
+
+interface FormLayoutProps {
+  form: FormElement[];
+}
+
+const FormLayout: FC<FormLayoutProps> = ({ form }) => (
+  <Stack gap={3} className="py-4">
+    {form.map((field) => {
+      if (field.type === 'title') {
+        return <h3 className="h3 text-primary-400">{field.label}</h3>;
+      }
+
+      if (field.type === 'divider') {
+        return <hr className="w-100" />;
+      }
+
+      if (field.type === 'group') {
+        return (
+          <Form.Row>
+            {field.fields.map((groupField) => (
+              <FormField {...groupField as BaseFormField} as={Col} />
+            ))}
+          </Form.Row>
+        );
+      }
+
+      return (<FormField {...field as BaseFormField} />);
+    })}
+  </Stack>
+);
+
+export default FormLayout;

--- a/src/app/FormLayout/types.ts
+++ b/src/app/FormLayout/types.ts
@@ -1,0 +1,24 @@
+export type FormFieldType = 'text' | 'email' | 'number' | 'date' | 'switch' | 'multiple-text';
+
+export interface BaseFormField {
+  name: string;
+  label: string;
+  type: FormFieldType;
+  as?: React.ElementType;
+}
+
+export interface FormGroup {
+  type: 'group';
+  fields: BaseFormField[];
+}
+
+export interface FormTitle {
+  type: 'title';
+  label: string;
+}
+
+export interface FormDivider {
+  type: 'divider';
+}
+
+export type FormElement = BaseFormField | FormGroup | FormTitle | FormDivider;

--- a/src/app/ModalLayout.tsx
+++ b/src/app/ModalLayout.tsx
@@ -35,7 +35,7 @@ const ModalLayout: FC<ModalLayoutProps> = ({
         {children}
       </ModalDialog.Body>
 
-      <ModalDialog.Footer className="py-4 px-6">
+      <ModalDialog.Footer className="py-4 px-5">
         <ActionRow>
           <ModalDialog.CloseButton className="px-5" variant="outline-primary">
             {intl.formatMessage(messages.cancelButton)}

--- a/src/app/ModalLayout.tsx
+++ b/src/app/ModalLayout.tsx
@@ -35,9 +35,9 @@ const ModalLayout: FC<ModalLayoutProps> = ({
         {children}
       </ModalDialog.Body>
 
-      <ModalDialog.Footer>
+      <ModalDialog.Footer className="py-4 px-6">
         <ActionRow>
-          <ModalDialog.CloseButton variant="outline-primary">
+          <ModalDialog.CloseButton className="px-5" variant="outline-primary">
             {intl.formatMessage(messages.cancelButton)}
           </ModalDialog.CloseButton>
 

--- a/src/app/ModalLayout.tsx
+++ b/src/app/ModalLayout.tsx
@@ -1,0 +1,51 @@
+import { ActionRow, ModalDialog } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import React, { FC } from 'react';
+import messages from './messages';
+
+interface ModalLayoutProps {
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  actions: React.ReactNode | React.ReactNode[];
+  children: React.ReactNode;
+}
+
+const ModalLayout: FC<ModalLayoutProps> = ({
+  title, isOpen, actions, onClose, children,
+}) => {
+  const intl = useIntl();
+  return (
+    <ModalDialog
+      title={title}
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      hasCloseButton
+      isFullscreenOnMobile
+      isOverflowVisible={false}
+    >
+      <ModalDialog.Header className="bg-primary-500">
+        <ModalDialog.Title className="text-light-100">
+          {title}
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+
+      <ModalDialog.Body>
+        {children}
+      </ModalDialog.Body>
+
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton variant="outline-primary">
+            {intl.formatMessage(messages.cancelButton)}
+          </ModalDialog.CloseButton>
+
+          {actions}
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
+
+export default ModalLayout;

--- a/src/app/messages.js
+++ b/src/app/messages.js
@@ -36,6 +36,11 @@ const messages = defineMessages({
     defaultMessage: 'Back',
     description: 'Text for the back button in the app layout',
   },
+  cancelButton: {
+    id: 'app.cancel.button',
+    defaultMessage: 'Cancel',
+    description: 'Text for the cancel button in the app layout',
+  },
 });
 
 export default messages;

--- a/src/catalogs/components/CatalogsList.tsx
+++ b/src/catalogs/components/CatalogsList.tsx
@@ -11,7 +11,7 @@ import TableFooter from '@src/app/TableFooter';
 import ActionItem from '@src/app/ActionItem';
 
 import { useParams } from 'wouter';
-import { useState } from 'react';
+import { useCatalogFormModal } from '@src/hooks/useCatalogFormModal';
 import { getPartnerCatalogs, getPartnerDetails } from '../api';
 
 import messages from '../messages';
@@ -26,8 +26,9 @@ const CatalogsList = () => {
   const navigate = useNavigate();
   const intl = useIntl();
 
+  const { handleChangeSelectedCatalog } = useCatalogFormModal();
+
   const { partnerId } = useParams<{ partnerId: string }>();
-  const [selectedCatalogId, setSelectedCatalogId] = useState<number | string | null>(null);
 
   const { data: partnerCatalogs, isLoading: isLoadingCatalogs } = useSuspenseQuery({
     queryKey: ['partnerCatalogs'],
@@ -41,11 +42,11 @@ const CatalogsList = () => {
 
   const tableActions = [{
     type: 'view',
-    onClick: (partner: CorporateCatalog) => navigate(paths.courses.buildPath(String(partner.id))),
+    onClick: (catalog: CorporateCatalog) => navigate(paths.courses.buildPath(String(catalog.id))),
   }, {
     type: 'edit',
-    onClick: (partner: CorporateCatalog) => {
-      setSelectedCatalogId(partner.id);
+    onClick: (catalog: CorporateCatalog) => {
+      handleChangeSelectedCatalog(catalog.id);
     },
   }];
 

--- a/src/context/CatalogEditionModalContext.ts
+++ b/src/context/CatalogEditionModalContext.ts
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+
+import { CorporateCatalog } from '@src/app/types';
+
+export interface TCatalogEditionModalContext {
+  isOpen: boolean;
+  selectedCatalog: CorporateCatalog | null;
+  handleChangeSelectedCatalog: (catalogId: number | string | null) => void;
+}
+
+export const CatalogEditionModalContext = createContext<TCatalogEditionModalContext>({
+  isOpen: false,
+  selectedCatalog: null,
+  handleChangeSelectedCatalog: () => {},
+});

--- a/src/hooks/messages.js
+++ b/src/hooks/messages.js
@@ -1,0 +1,11 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  saveButton: {
+    id: 'app.save.button',
+    defaultMessage: 'Save',
+    description: 'Text for the save button in the app layout',
+  },
+});
+
+export default messages;

--- a/src/hooks/useCatalogFormModal.tsx
+++ b/src/hooks/useCatalogFormModal.tsx
@@ -7,6 +7,7 @@ import { Button, useToggle } from '@openedx/paragon';
 import ModalLayout from '@src/app/ModalLayout';
 import { CatalogEditionModalContext } from '@src/context/CatalogEditionModalContext';
 
+import CatalogEditForm from '@src/app/CatalogEditForm';
 import messages from './messages';
 
 interface CatalogEditModalProviderProps {
@@ -45,22 +46,16 @@ export const CatalogEditModalProvider: FC<CatalogEditModalProviderProps> = ({ ch
   return (
     <CatalogEditionModalContext.Provider value={value}>
       <ModalLayout
-        title={`Edit Catalog - ${selectedCatalogId}`}
+        title="Edit Catalog"
         isOpen={isOpen}
         onClose={handleCloseModal}
         actions={(
-          <Button variant="primary" onClick={handleCloseModal}>
+          <Button className="px-5" variant="primary" onClick={handleCloseModal}>
             {intl.formatMessage(messages.saveButton)}
           </Button>
         )}
       >
-        <p>
-          I&apos;m baby palo santo ugh celiac fashion axe. La croix lo-fi venmo whatever.
-          Beard man braid migas single-origin coffee forage ramps. Tumeric messenger
-          bag bicycle rights wayfarers, try-hard cronut blue bottle health goth.
-          Sriracha tumblr cardigan, cloud bread succulents tumeric copper mug marfa
-          semiotics woke next level organic roof party +1 try-hard.
-        </p>
+        <CatalogEditForm selectedCatalog={selectedCatalogId} />
       </ModalLayout>
 
       {children}

--- a/src/hooks/useCatalogFormModal.tsx
+++ b/src/hooks/useCatalogFormModal.tsx
@@ -1,0 +1,71 @@
+import {
+  FC, useContext, useEffect, useMemo, useState,
+} from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Button, useToggle } from '@openedx/paragon';
+
+import ModalLayout from '@src/app/ModalLayout';
+import { CatalogEditionModalContext } from '@src/context/CatalogEditionModalContext';
+
+import messages from './messages';
+
+interface CatalogEditModalProviderProps {
+  children: React.ReactNode | React.ReactNode[];
+}
+
+export const CatalogEditModalProvider: FC<CatalogEditModalProviderProps> = ({ children }) => {
+  const intl = useIntl();
+
+  const [isOpen, open, close] = useToggle(false);
+  const [selectedCatalogId, setSelectedCatalogId] = useState<number | string | null>(null);
+
+  const handleChangeSelectedCatalog = (catalogId: number | string | null) => {
+    setSelectedCatalogId(catalogId);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedCatalogId(null);
+    close();
+  };
+
+  useEffect(() => {
+    if (selectedCatalogId) { open(); }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCatalogId]);
+
+  const value = useMemo(
+    () => ({
+      isOpen,
+      selectedCatalog: null,
+      handleChangeSelectedCatalog,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isOpen],
+  );
+  return (
+    <CatalogEditionModalContext.Provider value={value}>
+      <ModalLayout
+        title={`Edit Catalog - ${selectedCatalogId}`}
+        isOpen={isOpen}
+        onClose={handleCloseModal}
+        actions={(
+          <Button variant="primary" onClick={handleCloseModal}>
+            {intl.formatMessage(messages.saveButton)}
+          </Button>
+        )}
+      >
+        <p>
+          I&apos;m baby palo santo ugh celiac fashion axe. La croix lo-fi venmo whatever.
+          Beard man braid migas single-origin coffee forage ramps. Tumeric messenger
+          bag bicycle rights wayfarers, try-hard cronut blue bottle health goth.
+          Sriracha tumblr cardigan, cloud bread succulents tumeric copper mug marfa
+          semiotics woke next level organic roof party +1 try-hard.
+        </p>
+      </ModalLayout>
+
+      {children}
+    </CatalogEditionModalContext.Provider>
+  );
+};
+
+export const useCatalogFormModal = () => useContext(CatalogEditionModalContext);


### PR DESCRIPTION
> [!NOTE]
> This edit modal was created as part of a context because, in this way, it can be opened from any place by filling the `selectedCatalogId` through the custom hook interface: this modal is required at `/catalogs/:partnerId/` for any of the catalogs in the list and at `/catalogs/:partnerId/courses` as an additional action for the `HeaderDescription`

This pull request introduces a new modal-based catalog editing workflow and refactors catalog editing state management to use React context. The main changes include implementing a context provider for the catalog edit modal, creating a dynamic form system for catalog editing, and updating the catalog list to use the new modal logic.

**Catalog Edit Modal & Context Management**

* Added `CatalogEditModalProvider` and `CatalogEditionModalContext` to manage modal open/close state and selected catalog via React context, replacing local state management. (`src/hooks/useCatalogFormModal.tsx`, `src/context/CatalogEditionModalContext.ts`) [[1]](diffhunk://#diff-081001fd46e7fc172cefbfa003356b247eaddb3a84cdfe6e22ebf6f868ac5e53R1-R66) [[2]](diffhunk://#diff-09a6583fedc38802ae37fe2cd9304af91180d192d19d146d740f37b38fd235ddR1-R15)
* Wrapped the app in `CatalogEditModalProvider` to enable modal state access throughout the app. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R4) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R17-R19)

**Dynamic Catalog Edit Form**

* Implemented a configurable, dynamic catalog edit form using `react-hook-form` and Paragon components, supporting grouped fields, switches, multiple text entries, and more. (`src/app/CatalogEditForm.tsx`, `src/app/FormLayout/index.tsx`, `src/app/FormLayout/FormField.tsx`, `src/app/FormLayout/types.ts`) [[1]](diffhunk://#diff-1bafe20a8c173d3570b38a6445c2544735d1af4aef61fe5c172a94e31b531b0dR1-R71) [[2]](diffhunk://#diff-6d2e67c09f20f0c1bf19a36f81cde72204ed80eb9719422436dcb6da766333bbR1-R36) [[3]](diffhunk://#diff-e778ada5d51d19088288e957eb693293be7906272552a4ffb2e1310c6c0c5c91R1-R59) [[4]](diffhunk://#diff-240f2179f6e45fe70e8ff92bf4104af39a0e2aaf0541d58ade17e04d92122b6aR1-R24)

**Modal UI Components**

* Created a reusable `ModalLayout` component for consistent modal dialogs, including support for actions and internationalized button labels. (`src/app/ModalLayout.tsx`, `src/app/messages.js`) [[1]](diffhunk://#diff-4821369545f4b3d56af1e1f3a2281dd3bb67209e51d9104ff7e8af701f791757R1-R51) [[2]](diffhunk://#diff-1b22762bb58998e54c9131c352654df90d9d3aa7ae208778a4c1101b0995a8f0R39-R43)
* Added internationalized messages for modal buttons. (`src/hooks/messages.js`)

**Catalog List Integration**

* Refactored `CatalogsList` to use the new modal context for editing, replacing local state and updating action handlers to trigger the modal. (`src/catalogs/components/CatalogsList.tsx`) [[1]](diffhunk://#diff-fc4def80dd342667a0b6f7904bc04bb2c536beda22c09d6125aa0cb58e27b3c0L14-R14) [[2]](diffhunk://#diff-fc4def80dd342667a0b6f7904bc04bb2c536beda22c09d6125aa0cb58e27b3c0R29-L30) [[3]](diffhunk://#diff-fc4def80dd342667a0b6f7904bc04bb2c536beda22c09d6125aa0cb58e27b3c0L44-R49)

### Screenshots
<img width="1871" height="933" alt="image" src="https://github.com/user-attachments/assets/f13e0194-a6a2-4067-873e-257b21cef303" />

<img width="1869" height="935" alt="image" src="https://github.com/user-attachments/assets/0030dd9f-f76a-499a-a2b1-f0a0f7e59057" />
