### PR TITLE
fix: update routes to match course requirements

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,17 +12,17 @@ export const paths = {
   },
 
   catalogs: {
-    path: '/catalogs/:partnerId/',
-    buildPath: (partnerId: string) => `/catalogs/${partnerId}/`,
+    path: '/:partnerId/',
+    buildPath: (partnerId: string) => `/${partnerId}/`,
   },
 
   courses: {
-    path: '/catalogs/:partnerId/courses',
-    buildPath: (partnerId: string) => `/catalogs/${partnerId}/courses`,
+    path: '/:partnerId/:catalogId/',
+    buildPath: (partnerId: string, catalogId: string) => `/${partnerId}/${catalogId}/`,
   },
 
   courseDetail: {
-    path: '/catalogs/:partnerId/courses/:courseId/',
-    buildPath: (partnerId: string, courseId: string) => `/catalogs/${partnerId}/courses/${courseId}/`,
+    path: '/:partnerId/:catalogId/:courseId/',
+    buildPath: (partnerId: string, catalogId: string, courseId: string) => `/${partnerId}/${catalogId}/${courseId}/`,
   },
 } as const;


### PR DESCRIPTION
Due to the simplicity on the application I suggest opt for a simpler URL, as well the routes for courses list is depending directly to partner when in reality a course is under a catalogs that belongs a partner.


Another approach that we can consider is
`/:partner_id/catalogs/:catalog_id/courses/courses_id`

> This could be useful if we notice that the ids are similar or not fully indicative of the content 