### PR TITLE
feat: add yup resolver for form validations & form submit handling

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -46,6 +46,8 @@ export type CorporateCatalog = {
   corporatePartner: number;
 };
 
+export type CorporateCatalogForm = Pick<CorporateCatalog, 'isPublic' | 'name' | 'catalogAlternativeLink' | 'supportEmail' | 'availableStartDate' | 'availableEndDate' | 'courseEnrollmentLimit' | 'userLimit' | 'emailRegexes' | 'customCourses' | 'isSelfEnrollment' >;
+
 export interface PaginatedResponse<T> {
   next: string | null;
   previous: string | null;

--- a/src/catalogs/api.ts
+++ b/src/catalogs/api.ts
@@ -2,7 +2,7 @@ import { getConfig, camelCaseObject } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { CorporateCatalog, PaginatedResponse } from '../app/types';
+import { CorporateCatalog, CorporateCatalogForm, PaginatedResponse } from '../app/types';
 
 export const getPartnerCatalogs = async (
   partnerId: string,
@@ -37,6 +37,21 @@ export const getCatalogDetails = async (
   try {
     const url = `${getConfig().LMS_BASE_URL}/corporate_access/api/v1/partners/${partnerId}/catalogs/${catalogId}/`;
     const response = await getAuthenticatedHttpClient().get(url);
+    return camelCaseObject(response.data);
+  } catch (error) {
+    logError(error);
+    return null;
+  }
+};
+
+export const updateCatalog = async (
+  partnerId: string,
+  catalogId: string | number,
+  data: CorporateCatalogForm,
+): Promise<CorporateCatalog | null> => {
+  try {
+    const url = `${getConfig().LMS_BASE_URL}/corporate_access/api/v1/partners/${partnerId}/catalogs/${catalogId}/`;
+    const response = await getAuthenticatedHttpClient().put(url, data);
     return camelCaseObject(response.data);
   } catch (error) {
     logError(error);

--- a/src/catalogs/api.ts
+++ b/src/catalogs/api.ts
@@ -44,7 +44,7 @@ export const getCatalogDetails = async (
   }
 };
 
-export const updateCatalog = async (
+export const modifyCatalog = async (
   partnerId: string,
   catalogId: string | number,
   data: CorporateCatalogForm,

--- a/src/catalogs/components/CatalogEditForm/index.tsx
+++ b/src/catalogs/components/CatalogEditForm/index.tsx
@@ -1,18 +1,17 @@
 import { useImperativeHandle, forwardRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useParams } from 'wouter';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Col, Form, Stack } from '@openedx/paragon';
 
-import { useCatalogDetails, useYupValidationResolver } from '@src/catalogs/hooks';
+import { useYupValidationResolver } from '@src/catalogs/hooks';
 
-import { CorporateCatalogForm } from '@src/app/types';
+import { CorporateCatalog, CorporateCatalogForm } from '@src/app/types';
 import { getCatalogSchema } from './validationSchema';
 import { EMPTY_FORM_STATE } from './constants';
 import messages from './messages';
 
 interface CatalogEditFormProps {
-  selectedCatalog: string | number;
+  catalogDetails: CorporateCatalog;
   onSubmit: (data: CorporateCatalogForm) => void;
 }
 
@@ -21,13 +20,8 @@ export interface CatalogEditFormRef {
 }
 
 const CatalogEditForm = forwardRef<CatalogEditFormRef, CatalogEditFormProps>(
-  ({ selectedCatalog, onSubmit }, ref) => {
+  ({ catalogDetails, onSubmit }, ref) => {
     const intl = useIntl();
-    const { partnerId } = useParams<{ partnerId: string }>();
-    const { catalogDetails } = useCatalogDetails({
-      partnerId,
-      selectedCatalog,
-    });
 
     const resolver = useYupValidationResolver(getCatalogSchema(intl));
     const {

--- a/src/catalogs/components/CatalogEditForm/index.tsx
+++ b/src/catalogs/components/CatalogEditForm/index.tsx
@@ -1,175 +1,242 @@
-import { FC } from 'react';
+import { useImperativeHandle, forwardRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useParams } from 'wouter';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Col, Form, Stack } from '@openedx/paragon';
 
-import { useCatalogDetails } from '@src/catalogs/hooks';
+import { useCatalogDetails, useYupValidationResolver } from '@src/catalogs/hooks';
 
+import { CorporateCatalogForm } from '@src/app/types';
+import { getCatalogSchema } from './validationSchema';
 import { EMPTY_FORM_STATE } from './constants';
 import messages from './messages';
 
 interface CatalogEditFormProps {
   selectedCatalog: string | number;
+  onSubmit: (data: CorporateCatalogForm) => void;
 }
 
-const CatalogEditForm: FC<CatalogEditFormProps> = ({ selectedCatalog }) => {
-  const intl = useIntl();
-  const { partnerId } = useParams<{ partnerId: string }>();
-  const { catalogDetails } = useCatalogDetails({
-    partnerId,
-    selectedCatalog,
-  });
+export interface CatalogEditFormRef {
+  submitForm: () => void;
+}
 
-  const { register, control } = useForm({
-    defaultValues: catalogDetails ?? EMPTY_FORM_STATE,
-    mode: 'onChange',
-  });
+const CatalogEditForm = forwardRef<CatalogEditFormRef, CatalogEditFormProps>(
+  ({ selectedCatalog, onSubmit }, ref) => {
+    const intl = useIntl();
+    const { partnerId } = useParams<{ partnerId: string }>();
+    const { catalogDetails } = useCatalogDetails({
+      partnerId,
+      selectedCatalog,
+    });
 
-  return (
-    <Stack gap={3} className="py-4">
-      {/* General Information Section */}
-      <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formGeneralInformation)}</h3>
+    const resolver = useYupValidationResolver(getCatalogSchema(intl));
+    const {
+      register, control, handleSubmit, formState: { errors },
+    } = useForm({
+      defaultValues: catalogDetails ?? EMPTY_FORM_STATE,
+      mode: 'onChange',
+      resolver,
+    });
 
-      {/* Public Catalog Switch */}
-      <Form.Group controlId="isPublic" className="d-flex align-items-center">
-        <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
-          {intl.formatMessage(messages.formIsPublic)}
-        </Form.Label>
-        <Form.Switch
-          {...register('isPublic', {
-            onChange: (e) => e.target.checked,
-          })}
-          floatLabelLeft
-        />
-      </Form.Group>
+    // Expose a form submit function to parent component
+    useImperativeHandle(ref, () => ({
+      submitForm: handleSubmit(onSubmit),
+    }));
 
-      {/* Catalog Name */}
-      <Form.Group controlId="name">
-        <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formName)}</Form.Label>
-        <Form.Control id="name" {...register('name')} type="text" />
-      </Form.Group>
+    return (
+      <Stack gap={3} className="py-4">
+        {/* General Information Section */}
+        <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formGeneralInformation)}</h3>
 
-      {/* Alternative Link */}
-      <Form.Group controlId="catalogAlternativeLink">
-        <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formCatalogAlternativeLink)}</Form.Label>
-        <Form.Control id="catalogAlternativeLink" {...register('catalogAlternativeLink')} type="text" />
-      </Form.Group>
-
-      {/* Support Email */}
-      <Form.Group controlId="supportEmail">
-        <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formSupportEmail)}</Form.Label>
-        <Form.Control id="supportEmail" {...register('supportEmail')} type="email" />
-      </Form.Group>
-
-      {/* Date Range Group */}
-      <Form.Row>
-        <Controller
-          control={control}
-          name="availableStartDate"
-          render={({ field: { value, onChange } }) => (
-            <Form.Group as={Col} controlId="availableStartDate">
-              <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formAvailableStartDate)}</Form.Label>
-              <Form.Control
-                id="availableStartDate"
-                value={value ? new Date(value).toISOString().split('T')[0] : ''}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(new Date(e.target.value).toISOString())}
-                type="date"
-              />
-            </Form.Group>
-          )}
-        />
-        <Controller
-          control={control}
-          name="availableEndDate"
-          render={({ field: { value, onChange } }) => (
-            <Form.Group as={Col} controlId="availableEndDate">
-              <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formAvailableEndDate)}</Form.Label>
-              <Form.Control
-                id="availableEndDate"
-                value={value ? new Date(value).toISOString().split('T')[0] : ''}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const date = e.target.value;
-                  // Set time to 23:59:59.999 for the selected day
-                  const endDate = new Date(date);
-                  endDate.setHours(23, 59, 59, 999);
-                  onChange(endDate.toISOString());
-                }}
-                type="date"
-              />
-            </Form.Group>
-          )}
-        />
-      </Form.Row>
-
-      {/* Divider */}
-      <hr className="w-100" />
-
-      {/* Enrollment Settings Section */}
-      <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formEnrollmentSettings)}</h3>
-
-      {/* Enrollment Limits Group */}
-      <Form.Row>
-        <Form.Group as={Col} controlId="courseEnrollmentLimit">
-          <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formCourseEnrollmentLimit)}</Form.Label>
-          <Form.Control id="courseEnrollmentLimit" {...register('courseEnrollmentLimit')} type="number" />
+        {/* Public Catalog Switch */}
+        <Form.Group controlId="isPublic" className="d-flex align-items-center">
+          <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
+            {intl.formatMessage(messages.formIsPublic)}
+          </Form.Label>
+          <Form.Switch
+            {...register('isPublic', {
+              onChange: (e) => e.target.checked,
+            })}
+            floatLabelLeft
+          />
         </Form.Group>
-        <Form.Group as={Col} controlId="userLimit">
-          <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formUserLimit)}</Form.Label>
-          <Form.Control id="userLimit" {...register('userLimit')} type="number" />
+
+        {/* Catalog Name */}
+        <Form.Group isInvalid={!!errors.name} controlId="name">
+          <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formName)}</Form.Label>
+          <Form.Control id="name" {...register('name')} type="text" />
+          {errors.name && (
+          <Form.Control.Feedback type="invalid">
+            {errors.name?.message}
+          </Form.Control.Feedback>
+          )}
         </Form.Group>
-      </Form.Row>
 
-      {/* Divider */}
-      <hr className="w-100" />
+        {/* Alternative Link */}
+        <Form.Group isInvalid={!!errors.catalogAlternativeLink} controlId="catalogAlternativeLink">
+          <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formCatalogAlternativeLink)}</Form.Label>
+          <Form.Control id="catalogAlternativeLink" {...register('catalogAlternativeLink')} type="text" />
+          {errors.catalogAlternativeLink && (
+          <Form.Control.Feedback type="invalid">
+            {errors.catalogAlternativeLink?.message}
+          </Form.Control.Feedback>
+          )}
+        </Form.Group>
 
-      {/* Advanced Settings Section */}
-      <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formAdvancedSettings)}</h3>
+        {/* Support Email */}
+        <Form.Group isInvalid={!!errors.supportEmail} controlId="supportEmail">
+          <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formSupportEmail)}</Form.Label>
+          <Form.Control id="supportEmail" {...register('supportEmail')} type="email" />
+          {errors.supportEmail && (
+          <Form.Control.Feedback type="invalid">
+            {errors.supportEmail?.message}
+          </Form.Control.Feedback>
+          )}
+        </Form.Group>
 
-      {/* Email Regexes */}
-      <Controller
-        control={control}
-        name="emailRegexes"
-        render={({ field: { value, onChange } }) => (
-          <Form.Group controlId="emailRegexes">
-            <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formEmailRegexes)}</Form.Label>
-            <Form.Control
-              id="emailRegexes"
-              type="text"
-              value={Array.isArray(value) ? value.join(', ') : value || ''}
-              onChange={(e) => onChange(e.target.value.split(',').map((v) => v.trim()))}
-            />
+        {/* Date Range Group */}
+        <Form.Row>
+          <Controller
+            control={control}
+            name="availableStartDate"
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Form.Group isInvalid={!!error} as={Col} controlId="availableStartDate">
+                <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formAvailableStartDate)}</Form.Label>
+                <Form.Control
+                  id="availableStartDate"
+                  value={value ? new Date(value).toISOString().split('T')[0] : ''}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const dateValue = e.target.value;
+                    if (dateValue) {
+                      const date = new Date(dateValue);
+                      // Check if the date is valid
+                      if (!Number.isNaN(date.getTime())) {
+                        onChange(date.toISOString());
+                      }
+                    } else {
+                      // Handle empty date input
+                      onChange(null);
+                    }
+                  }}
+                  type="date"
+                />
+                {error && <Form.Control.Feedback type="invalid">{error.message}</Form.Control.Feedback>}
+              </Form.Group>
+            )}
+          />
+          <Controller
+            control={control}
+            name="availableEndDate"
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Form.Group isInvalid={!!error} as={Col} controlId="availableEndDate">
+                <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formAvailableEndDate)}</Form.Label>
+                <Form.Control
+                  id="availableEndDate"
+                  value={value ? new Date(value).toISOString().split('T')[0] : ''}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const dateValue = e.target.value;
+                    if (dateValue) {
+                      const date = new Date(dateValue);
+                      // Check if the date is valid
+                      if (!Number.isNaN(date.getTime())) {
+                        // Set time to 23:59:59.999 for the selected day
+                        date.setHours(23, 59, 59, 999);
+                        onChange(date.toISOString());
+                      }
+                    } else {
+                      // Handle empty date input
+                      onChange(null);
+                    }
+                  }}
+                  type="date"
+                />
+                {error && <Form.Control.Feedback type="invalid">{error.message}</Form.Control.Feedback>}
+              </Form.Group>
+            )}
+          />
+        </Form.Row>
+
+        {/* Divider */}
+        <hr className="w-100" />
+
+        {/* Enrollment Settings Section */}
+        <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formEnrollmentSettings)}</h3>
+
+        {/* Enrollment Limits Group */}
+        <Form.Row>
+          <Form.Group isInvalid={!!errors.courseEnrollmentLimit} as={Col} controlId="courseEnrollmentLimit">
+            <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formCourseEnrollmentLimit)}</Form.Label>
+            <Form.Control id="courseEnrollmentLimit" {...register('courseEnrollmentLimit')} type="number" />
+            {errors.courseEnrollmentLimit && (
+              <Form.Control.Feedback type="invalid">
+                {errors.courseEnrollmentLimit?.message}
+              </Form.Control.Feedback>
+            )}
           </Form.Group>
-        )}
-      />
+          <Form.Group isInvalid={!!errors.userLimit} as={Col} controlId="userLimit">
+            <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formUserLimit)}</Form.Label>
+            <Form.Control id="userLimit" {...register('userLimit')} type="number" />
+            {errors.userLimit && (
+              <Form.Control.Feedback type="invalid">
+                {errors.userLimit?.message}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+        </Form.Row>
 
-      {/* Custom Courses Switch */}
-      <Form.Group controlId="customCourses" className="d-flex align-items-center">
-        <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
-          {intl.formatMessage(messages.formCustomCourses)}
-        </Form.Label>
-        <Form.Switch
-          {...register('customCourses', {
-            onChange: (e) => e.target.checked,
-          })}
-          floatLabelLeft
-        />
-      </Form.Group>
+        {/* Divider */}
+        <hr className="w-100" />
 
-      {/* Self Enrollment Switch */}
-      <Form.Group controlId="isSelfEnrollment" className="d-flex align-items-center">
-        <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
-          {intl.formatMessage(messages.formIsSelfEnrollment)}
-        </Form.Label>
-        <Form.Switch
-          {...register('isSelfEnrollment', {
-            onChange: (e) => e.target.checked,
-          })}
-          floatLabelLeft
+        {/* Advanced Settings Section */}
+        <h3 className="h3 text-primary-400">{intl.formatMessage(messages.formAdvancedSettings)}</h3>
+
+        {/* Email Regexes */}
+        <Controller
+          control={control}
+          name="emailRegexes"
+          render={({ field: { value, onChange } }) => (
+            <Form.Group controlId="emailRegexes">
+              <Form.Label className="font-weight-bold">{intl.formatMessage(messages.formEmailRegexes)}</Form.Label>
+              <Form.Control
+                id="emailRegexes"
+                type="text"
+                value={Array.isArray(value) ? value.join(', ') : value || ''}
+                onChange={(e) => onChange(e.target.value.split(',').map((v) => v.trim()))}
+              />
+            </Form.Group>
+          )}
         />
-      </Form.Group>
-    </Stack>
-  );
-};
+
+        {/* Custom Courses Switch */}
+        <Form.Group controlId="customCourses" className="d-flex align-items-center">
+          <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
+            {intl.formatMessage(messages.formCustomCourses)}
+          </Form.Label>
+          <Form.Switch
+            {...register('customCourses', {
+              onChange: (e) => e.target.checked,
+            })}
+            floatLabelLeft
+          />
+        </Form.Group>
+
+        {/* Self Enrollment Switch */}
+        <Form.Group controlId="isSelfEnrollment" className="d-flex align-items-center">
+          <Form.Label className="mb-0 flex-grow-1 font-weight-bold">
+            {intl.formatMessage(messages.formIsSelfEnrollment)}
+          </Form.Label>
+          <Form.Switch
+            {...register('isSelfEnrollment', {
+              onChange: (e) => e.target.checked,
+            })}
+            floatLabelLeft
+          />
+        </Form.Group>
+      </Stack>
+    );
+  },
+);
+
+CatalogEditForm.displayName = 'CatalogEditForm';
 
 export default CatalogEditForm;

--- a/src/catalogs/components/CatalogEditForm/messages.js
+++ b/src/catalogs/components/CatalogEditForm/messages.js
@@ -71,6 +71,81 @@ const messages = defineMessages({
     defaultMessage: 'Self Enrollment',
     description: 'Label for the self enrollment switch',
   },
+  formNameRequired: {
+    id: 'form.name.required',
+    defaultMessage: 'Catalog name is required',
+    description: 'Error message for required catalog name',
+  },
+  formNameMin: {
+    id: 'form.name.min',
+    defaultMessage: 'Catalog name must be at least {min} characters',
+    description: 'Error message for minimum length of catalog name',
+  },
+  formNameMax: {
+    id: 'form.name.max',
+    defaultMessage: 'Catalog name cannot exceed {max} characters',
+    description: 'Error message for maximum length of catalog name',
+  },
+  formCatalogAlternativeLinkInvalid: {
+    id: 'form.catalog.alternative.link.invalid',
+    defaultMessage: 'Please enter a valid URL',
+    description: 'Error message for invalid alternative link URL',
+  },
+  formSupportEmailRequired: {
+    id: 'form.support.email.required',
+    defaultMessage: 'Support email is required',
+    description: 'Error message for required support email',
+  },
+  formSupportEmailInvalid: {
+    id: 'form.support.email.invalid',
+    defaultMessage: 'Please enter a valid email address',
+    description: 'Error message for invalid support email format',
+  },
+  formAvailableStartDateRequired: {
+    id: 'form.available.start.date.required',
+    defaultMessage: 'Start date is required',
+    description: 'Error message for required start date',
+  },
+  formAvailableStartDateInvalid: {
+    id: 'form.available.start.date.invalid',
+    defaultMessage: 'Please enter a valid start date',
+    description: 'Error message for invalid start date format',
+  },
+  formAvailableEndDateRequired: {
+    id: 'form.available.end.date.required',
+    defaultMessage: 'End date is required',
+    description: 'Error message for required end date',
+  },
+  formAvailableEndDateInvalid: {
+    id: 'form.available.end.date.invalid',
+    defaultMessage: 'Please enter a valid end date',
+    description: 'Error message for invalid end date format',
+  },
+  formAvailableEndDateMin: {
+    id: 'form.available.end.date.min',
+    defaultMessage: 'End date must be after start date',
+    description: 'Error message when end date is before start date',
+  },
+  formCourseEnrollmentLimitMin: {
+    id: 'form.course.enrollment.limit.min',
+    defaultMessage: 'Course enrollment must be at least {min} participants',
+    description: 'Error message for negative course enrollment limit',
+  },
+  formCourseEnrollmentLimitInteger: {
+    id: 'form.course.enrollment.limit.integer',
+    defaultMessage: 'Course enrollment limit must be a whole number',
+    description: 'Error message for non-integer course enrollment limit',
+  },
+  formUserLimitMin: {
+    id: 'form.user.limit.min',
+    defaultMessage: 'User limit cannot be negative',
+    description: 'Error message for negative user limit',
+  },
+  formUserLimitInteger: {
+    id: 'form.user.limit.integer',
+    defaultMessage: 'User limit must be a whole number',
+    description: 'Error message for non-integer user limit',
+  },
 });
 
 export default messages;

--- a/src/catalogs/components/CatalogEditForm/validationSchema.ts
+++ b/src/catalogs/components/CatalogEditForm/validationSchema.ts
@@ -1,0 +1,63 @@
+import * as yup from 'yup';
+import messages from './messages';
+
+export const getCatalogSchema = (intl) => {
+  const CATALOG_NAME_MIN = 3;
+  const CATALOG_NAME_MAX = 100;
+  const COURSE_ENROLLMENT_LIMIT_MIN = 0;
+  const USER_LIMIT_MIN = 0;
+
+  return yup.object({
+    isPublic: yup.boolean(),
+    name: yup
+      .string()
+      .required(intl.formatMessage(messages.formNameRequired))
+      .min(CATALOG_NAME_MIN, intl.formatMessage(messages.formNameMin, { min: CATALOG_NAME_MIN }))
+      .max(CATALOG_NAME_MAX, intl.formatMessage(messages.formNameMax, { max: CATALOG_NAME_MAX })),
+    catalogAlternativeLink: yup
+      .string()
+      .url(intl.formatMessage(messages.formCatalogAlternativeLinkInvalid)),
+    supportEmail: yup
+      .string()
+      .email(intl.formatMessage(messages.formSupportEmailInvalid))
+      .required(intl.formatMessage(messages.formSupportEmailRequired)),
+    availableStartDate: yup
+      .date()
+      .required(intl.formatMessage(messages.formAvailableStartDateRequired))
+      .typeError(intl.formatMessage(messages.formAvailableStartDateInvalid)),
+    availableEndDate: yup
+      .date()
+      .required(intl.formatMessage(messages.formAvailableEndDateRequired))
+      .typeError(intl.formatMessage(messages.formAvailableEndDateInvalid))
+      .test(
+        'is-after-start-date',
+        intl.formatMessage(messages.formAvailableEndDateMin),
+        function validateEndDate(availableEndDate) {
+          const { availableStartDate } = this.parent;
+          if (!availableEndDate || !availableStartDate) { return true; }
+          return new Date(availableEndDate) > new Date(availableStartDate);
+        },
+      ),
+    courseEnrollmentLimit: yup
+      .number()
+      .typeError(intl.formatMessage(messages.formCourseEnrollmentLimitInteger))
+      .integer(intl.formatMessage(messages.formCourseEnrollmentLimitInteger))
+      .min(
+        COURSE_ENROLLMENT_LIMIT_MIN,
+        intl.formatMessage(messages.formCourseEnrollmentLimitMin, { min: COURSE_ENROLLMENT_LIMIT_MIN }),
+      ),
+    userLimit: yup
+      .number()
+      .typeError(intl.formatMessage(messages.formUserLimitInteger))
+      .integer(intl.formatMessage(messages.formUserLimitInteger))
+      .min(
+        USER_LIMIT_MIN,
+        intl.formatMessage(messages.formUserLimitMin, { min: USER_LIMIT_MIN }),
+      ),
+    emailRegexes: yup
+      .array()
+      .of(yup.string().required()),
+    customCourses: yup.boolean(),
+    isSelfEnrollment: yup.boolean(),
+  });
+};

--- a/src/catalogs/components/CatalogEditForm/validationSchema.ts
+++ b/src/catalogs/components/CatalogEditForm/validationSchema.ts
@@ -2,8 +2,8 @@ import * as yup from 'yup';
 import messages from './messages';
 
 export const getCatalogSchema = (intl) => {
-  const CATALOG_NAME_MIN = 3;
-  const CATALOG_NAME_MAX = 100;
+  const CATALOG_NAME_MIN_LENGTH = 3;
+  const CATALOG_NAME_MAX_LENGTH = 100;
   const COURSE_ENROLLMENT_LIMIT_MIN = 0;
   const USER_LIMIT_MIN = 0;
 
@@ -12,8 +12,8 @@ export const getCatalogSchema = (intl) => {
     name: yup
       .string()
       .required(intl.formatMessage(messages.formNameRequired))
-      .min(CATALOG_NAME_MIN, intl.formatMessage(messages.formNameMin, { min: CATALOG_NAME_MIN }))
-      .max(CATALOG_NAME_MAX, intl.formatMessage(messages.formNameMax, { max: CATALOG_NAME_MAX })),
+      .min(CATALOG_NAME_MIN_LENGTH, intl.formatMessage(messages.formNameMin, { min: CATALOG_NAME_MIN_LENGTH }))
+      .max(CATALOG_NAME_MAX_LENGTH, intl.formatMessage(messages.formNameMax, { max: CATALOG_NAME_MAX_LENGTH })),
     catalogAlternativeLink: yup
       .string()
       .url(intl.formatMessage(messages.formCatalogAlternativeLinkInvalid)),

--- a/src/catalogs/components/CatalogsList.test.tsx
+++ b/src/catalogs/components/CatalogsList.test.tsx
@@ -19,6 +19,7 @@ jest.mock('@src/hooks', () => ({
 jest.mock('@src/catalogs/useCatalogEditionModal', () => ({
   useCatalogEditionModal: () => ({
     handleChangeSelectedCatalog: jest.fn(),
+    registerRefetchCallback: jest.fn(),
   }),
 }));
 

--- a/src/catalogs/components/CatalogsList.tsx
+++ b/src/catalogs/components/CatalogsList.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { DataTable, TextFilter } from '@openedx/paragon';
 
@@ -26,15 +26,19 @@ const CatalogsList: FC<CatalogsListProps> = ({ partnerId }) => {
   const navigate = useNavigate();
   const intl = useIntl();
 
-  const { handleChangeSelectedCatalog } = useCatalogEditionModal();
-
   const { pageIndex, pageSize, onPaginationChange } = usePagination();
 
-  const { partnerCatalogs, isLoadingCatalogs } = usePartnerCatalogs({
+  const { handleChangeSelectedCatalog, registerRefetchCallback } = useCatalogEditionModal();
+  const { partnerCatalogs, isLoadingCatalogs, refetchCatalogs } = usePartnerCatalogs({
     partnerId,
     pageIndex: pageIndex + 1,
     pageSize,
   });
+
+  useEffect(() => {
+    registerRefetchCallback(refetchCatalogs);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refetchCatalogs]);
 
   const tableActions = [{
     type: 'view',

--- a/src/catalogs/context/CatalogEditionModalContext.ts
+++ b/src/catalogs/context/CatalogEditionModalContext.ts
@@ -3,13 +3,15 @@ import { createContext } from 'react';
 import { CorporateCatalog } from '@src/app/types';
 
 export interface TCatalogEditionModalContext {
-  isOpen: boolean;
+  isModalOpen: boolean;
   selectedCatalog: CorporateCatalog | null;
   handleChangeSelectedCatalog: (catalogId: number | string | null) => void;
+  registerRefetchCallback: (callback: () => void) => void;
 }
 
 export const CatalogEditionModalContext = createContext<TCatalogEditionModalContext>({
-  isOpen: false,
+  isModalOpen: false,
   selectedCatalog: null,
   handleChangeSelectedCatalog: () => {},
+  registerRefetchCallback: () => {},
 });

--- a/src/catalogs/hooks.ts
+++ b/src/catalogs/hooks.ts
@@ -1,26 +1,30 @@
 import { useCallback } from 'react';
 import { FieldValues, Resolver } from 'react-hook-form';
 import { SchemaOf } from 'yup';
-import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation, useQuery, useQueryClient, useSuspenseQuery,
+} from '@tanstack/react-query';
 
-import { CorporateCatalog, PaginatedResponse } from '@src/app/types';
-import { getCatalogDetails, getPartnerCatalogs } from './api';
+import { CorporateCatalog, CorporateCatalogForm, PaginatedResponse } from '@src/app/types';
+import {
+  getCatalogDetails, getPartnerCatalogs, updateCatalog,
+} from './api';
 
 export const usePartnerCatalogs = (
   { partnerId, pageIndex, pageSize }: { partnerId: string; pageIndex: number; pageSize: number; },
 ) => {
-  const { data: partnerCatalogs, isLoading: isLoadingCatalogs } = useSuspenseQuery({
+  const { data: partnerCatalogs, isLoading: isLoadingCatalogs, refetch: refetchCatalogs } = useSuspenseQuery({
     queryKey: ['partnerCatalogs', partnerId, pageIndex, pageSize],
     queryFn: () => getPartnerCatalogs(partnerId, pageIndex, pageSize),
   });
 
-  return { partnerCatalogs, isLoadingCatalogs };
+  return { partnerCatalogs, isLoadingCatalogs, refetchCatalogs };
 };
 
 export const useCatalogDetails = ({
   partnerId,
   selectedCatalog,
-}: { partnerId: string; selectedCatalog: string | number; }) => {
+}: { partnerId: string; selectedCatalog: string | number | null; }) => {
   const queryClient = useQueryClient();
 
   const allCatalogs = queryClient
@@ -29,16 +33,34 @@ export const useCatalogDetails = ({
 
   const catalogFromCache = allCatalogs.find((c) => c.id === selectedCatalog);
 
-  const { data: catalogDetails, isLoading } = useQuery({
+  const { data: catalogDetails, isLoading, refetch } = useQuery({
     queryKey: ['catalogDetails', partnerId, selectedCatalog],
-    queryFn: () => getCatalogDetails(partnerId, selectedCatalog),
+    queryFn: () => getCatalogDetails(partnerId, selectedCatalog || 0),
     enabled: !catalogFromCache && !!partnerId && !!selectedCatalog,
   });
 
   return {
     catalogDetails: catalogFromCache || catalogDetails || null,
     isLoadingCatalogDetails: isLoading,
+    refetchCatalogDetails: refetch,
   };
+};
+
+export const useUpdateCatalog = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: async ({
+      partnerId, catalogId, data,
+    }:
+    { partnerId: string; catalogId: string; data: CorporateCatalogForm }) => updateCatalog(partnerId, catalogId, data),
+    onSettled: (_data, _error, args) => {
+      queryClient.invalidateQueries({
+        queryKey: ['catalogDetails', args.partnerId, args.catalogId],
+        exact: false,
+      });
+    },
+  });
+  return mutate;
 };
 
 /**

--- a/src/catalogs/hooks.ts
+++ b/src/catalogs/hooks.ts
@@ -7,7 +7,7 @@ import {
 
 import { CorporateCatalog, CorporateCatalogForm, PaginatedResponse } from '@src/app/types';
 import {
-  getCatalogDetails, getPartnerCatalogs, updateCatalog,
+  getCatalogDetails, getPartnerCatalogs, modifyCatalog,
 } from './api';
 
 export const usePartnerCatalogs = (
@@ -46,13 +46,13 @@ export const useCatalogDetails = ({
   };
 };
 
-export const useUpdateCatalog = () => {
+export const useModifyCatalog = () => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
     mutationFn: async ({
       partnerId, catalogId, data,
     }:
-    { partnerId: string; catalogId: string; data: CorporateCatalogForm }) => updateCatalog(partnerId, catalogId, data),
+    { partnerId: string; catalogId: string; data: CorporateCatalogForm }) => modifyCatalog(partnerId, catalogId, data),
     onSettled: (_data, _error, args) => {
       queryClient.invalidateQueries({
         queryKey: ['catalogDetails', args.partnerId, args.catalogId],

--- a/src/catalogs/useCatalogEditionModal.tsx
+++ b/src/catalogs/useCatalogEditionModal.tsx
@@ -1,12 +1,13 @@
 import {
-  FC, useContext, useEffect, useMemo, useState,
+  FC, useContext, useEffect, useMemo, useState, useRef,
 } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button, useToggle } from '@openedx/paragon';
 
 import ModalLayout from '@src/app/ModalLayout';
 
-import CatalogEditForm from './components/CatalogEditForm';
+import { CorporateCatalogForm } from '@src/app/types';
+import CatalogEditForm, { CatalogEditFormRef } from './components/CatalogEditForm';
 import messages from './messages';
 import { CatalogEditionModalContext } from './context/CatalogEditionModalContext';
 
@@ -16,6 +17,7 @@ interface CatalogEditionModalProviderProps {
 
 export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> = ({ children }) => {
   const intl = useIntl();
+  const formRef = useRef<CatalogEditFormRef>(null);
 
   const [isOpen, open, close] = useToggle(false);
   const [selectedCatalogId, setSelectedCatalogId] = useState<number | string | null>(null);
@@ -27,6 +29,15 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
   const handleCloseModal = () => {
     setSelectedCatalogId(null);
     close();
+  };
+
+  const handleSave = () => {
+    if (formRef.current) { formRef.current.submitForm(); }
+  };
+
+  const handleFormSubmit = (data: CorporateCatalogForm) => {
+    if (data) { console.log(data); }
+    handleCloseModal();
   };
 
   useEffect(() => {
@@ -50,12 +61,18 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
         isOpen={isOpen}
         onClose={handleCloseModal}
         actions={(
-          <Button className="px-5" variant="primary" onClick={handleCloseModal}>
+          <Button className="px-5" variant="primary" onClick={handleSave}>
             {intl.formatMessage(messages.saveButton)}
           </Button>
         )}
       >
-        {selectedCatalogId && <CatalogEditForm selectedCatalog={selectedCatalogId} />}
+        {selectedCatalogId && (
+          <CatalogEditForm
+            ref={formRef}
+            selectedCatalog={selectedCatalogId}
+            onSubmit={handleFormSubmit}
+          />
+        )}
       </ModalLayout>
 
       {children}

--- a/src/catalogs/useCatalogEditionModal.tsx
+++ b/src/catalogs/useCatalogEditionModal.tsx
@@ -11,7 +11,7 @@ import { useParams } from 'wouter';
 import CatalogEditForm, { CatalogEditFormRef } from './components/CatalogEditForm';
 import messages from './messages';
 import { CatalogEditionModalContext } from './context/CatalogEditionModalContext';
-import { useCatalogDetails, useUpdateCatalog } from './hooks';
+import { useCatalogDetails, useModifyCatalog } from './hooks';
 
 interface CatalogEditionModalProviderProps {
   children: React.ReactNode | React.ReactNode[];
@@ -27,7 +27,7 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
   const [selectedCatalogId, setSelectedCatalogId] = useState<string | null>(null);
   const [refetchCallback, setRefetchCallback] = useState<(() => void) | null>(null);
 
-  const updateCatalog = useUpdateCatalog();
+  const modifyCatalog = useModifyCatalog();
   const { catalogDetails, refetchCatalogDetails } = useCatalogDetails({
     partnerId,
     selectedCatalog: selectedCatalogId,
@@ -52,7 +52,7 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
 
   const handleFormSubmit = (data: CorporateCatalogForm) => {
     if (data && selectedCatalogId) {
-      updateCatalog({ partnerId, catalogId: selectedCatalogId, data }, {
+      modifyCatalog({ partnerId, catalogId: selectedCatalogId, data }, {
         onSuccess: () => {
           if (refetchCallback) { refetchCallback(); }
           refetchCatalogDetails();

--- a/src/catalogs/useCatalogEditionModal.tsx
+++ b/src/catalogs/useCatalogEditionModal.tsx
@@ -37,11 +37,6 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
     setSelectedCatalogId(catalogId);
   };
 
-  const handleCloseModal = () => {
-    closeModal();
-    setSelectedCatalogId(null);
-  };
-
   const registerRefetchCallback = useCallback((callback: () => void) => {
     setRefetchCallback(() => callback);
   }, []);
@@ -56,7 +51,7 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
         onSuccess: () => {
           if (refetchCallback) { refetchCallback(); }
           refetchCatalogDetails();
-          handleCloseModal();
+          setSelectedCatalogId(null);
         },
       });
     }
@@ -64,7 +59,7 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
 
   useEffect(() => {
     if (selectedCatalogId) { openModal(); }
-    if (!selectedCatalogId) { handleCloseModal(); }
+    if (!selectedCatalogId) { closeModal(); }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCatalogId]);
 
@@ -83,7 +78,7 @@ export const CatalogEditionModalProvider: FC<CatalogEditionModalProviderProps> =
       <ModalLayout
         title={intl.formatMessage(messages.editCatalogTitle)}
         isOpen={isModalOpen}
-        onClose={handleCloseModal}
+        onClose={() => setSelectedCatalogId(null)}
         actions={(
           <Button className="px-5" variant="primary" onClick={handleSaveData}>
             {intl.formatMessage(messages.saveButton)}


### PR DESCRIPTION
This pull request introduces form validation and refactoring to the catalog editing workflow, ensuring that user input is validated before submission. The main changes include adding a Yup validation schema, integrating validation with React Hook Form, updating the UI to display error messages, and refactoring the modal to handle form submission.

**Form Validation and Schema Integration**
- Added a Yup-based validation schema for the catalog edit form, enforcing rules such as required fields, minimum/maximum lengths, valid email/URL formats, and logical date ranges.
- Implemented a custom hook `useYupValidationResolver` to connect Yup validation with React Hook Form, allowing for synchronous error handling and validation feedback. [[1]](diffhunk://#diff-5be2695b64136781c6a3938abca4cbd41dfdcdcb4861560f1b9cc5f3934cf14fR1-R5) [[2]](diffhunk://#diff-5be2695b64136781c6a3938abca4cbd41dfdcdcb4861560f1b9cc5f3934cf14fR43-R82)

**UI and Error Feedback Enhancements**
- Updated the `CatalogEditForm` to display validation errors inline for each field, improving user feedback and form usability. [[1]](diffhunk://#diff-1cc3aa38f66fdea3439916bc8e59cd4b1d728e77f032b9e57928d72335b1d403L48-R153) [[2]](diffhunk://#diff-1cc3aa38f66fdea3439916bc8e59cd4b1d728e77f032b9e57928d72335b1d403L113-R183)
- Expanded the `messages.js` file to include localized error messages for all validation scenarios.

**Component Refactoring and Submission Handling**
- Refactored `CatalogEditForm` to use `forwardRef` and expose a `submitForm` method, enabling parent components to trigger form submission. [[1]](diffhunk://#diff-1cc3aa38f66fdea3439916bc8e59cd4b1d728e77f032b9e57928d72335b1d403L1-R45) [[2]](diffhunk://#diff-1cc3aa38f66fdea3439916bc8e59cd4b1d728e77f032b9e57928d72335b1d403L173-R240)
- Modified `useCatalogEditionModal` to use a ref to the form and handle submission and modal closure based on validation results. [[1]](diffhunk://#diff-064d6a59080b90d04067012e4cffc8d3e2363f71e280f5c40161d56121f909c3L2-R10) [[2]](diffhunk://#diff-064d6a59080b90d04067012e4cffc8d3e2363f71e280f5c40161d56121f909c3R20) [[3]](diffhunk://#diff-064d6a59080b90d04067012e4cffc8d3e2363f71e280f5c40161d56121f909c3R34-R42) [[4]](diffhunk://#diff-064d6a59080b90d04067012e4cffc8d3e2363f71e280f5c40161d56121f909c3L53-R75)

**Type Definitions**
- Added a new `CorporateCatalogForm` type to restrict form fields to only those relevant for editing

### Screenshots
<img width="969" height="844" alt="image" src="https://github.com/user-attachments/assets/3c784530-d264-4834-aa56-d3a3bc5429f3" />
<img width="969" height="844" alt="image" src="https://github.com/user-attachments/assets/626513d8-effd-45e0-be8a-94dddd99be46" />
