### PR TITLE
fix: filter list to show only learners with active enrollment

### DIFF
--- a/src/catalogs/course-detail/data/api.ts
+++ b/src/catalogs/course-detail/data/api.ts
@@ -13,7 +13,7 @@ export const getCourseLearners = async (
   search?: string,
 ): Promise<PaginatedResponse<LearnerStatus>> => {
   try {
-    const url = new URL(getCorporateApi(`manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`));
+    const url = new URL(getCorporateApi(`manage/catalogs/${catalogId}/courses/${courseId}/enrollments/?active=true`));
     url.searchParams.append('page', pageIndex.toString());
     url.searchParams.append('page_size', pageSize.toString());
     if (ordering) {


### PR DESCRIPTION
This PR uses the query param `active` from https://github.com/fccn/openedx-corporate/pull/57 to display only the learners with an active course enrollment

### Screenshot
<img width="1871" height="1051" alt="Image" src="https://github.com/user-attachments/assets/a2b98c3f-260c-4e1f-9797-17578a050660" />