### PR TITLE
feat: implement CSV report download functionality

### DIFF
--- a/src/catalogs/components/DownloadReportButton.test.tsx
+++ b/src/catalogs/components/DownloadReportButton.test.tsx
@@ -1,0 +1,171 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWrapper } from '@src/setupTest';
+import DownloadReportButton from './DownloadReportButton';
+
+const mockUseDownloadReport = jest.fn();
+
+jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
+  useDownloadReport: (...args: any[]) => mockUseDownloadReport(...args),
+}));
+
+describe('DownloadReportButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+  });
+
+  it('renders with correct label', () => {
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /download report/i })).toBeInTheDocument();
+  });
+
+  it('calls mutate on button click', () => {
+    const mutateMock = jest.fn();
+    mockUseDownloadReport.mockReturnValue({
+      mutate: mutateMock,
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /download report/i });
+    fireEvent.click(button);
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('is disabled when isPending is true', () => {
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: true,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /download report/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('is not disabled when isPending is false', () => {
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /download report/i });
+    expect(button).not.toBeDisabled();
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+        disabled
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /download report/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('passes endpoint and filename to useDownloadReport hook', () => {
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="manage/catalogs/test/learners/"
+        filename="learners_report.csv"
+      />,
+    );
+
+    expect(mockUseDownloadReport).toHaveBeenCalledWith({
+      endpoint: 'manage/catalogs/test/learners/',
+      filename: 'learners_report.csv',
+      successMessage: undefined,
+    });
+  });
+
+  it('passes successMessage to useDownloadReport hook when provided', () => {
+    mockUseDownloadReport.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+        successMessage="Custom success message"
+      />,
+    );
+
+    expect(mockUseDownloadReport).toHaveBeenCalledWith({
+      endpoint: 'test/endpoint/',
+      filename: 'test_report.csv',
+      successMessage: 'Custom success message',
+    });
+  });
+
+  it('does not call mutate when disabled', () => {
+    const mutateMock = jest.fn();
+    mockUseDownloadReport.mockReturnValue({
+      mutate: mutateMock,
+      mutateAsync: jest.fn(),
+      isPending: true,
+    });
+
+    renderWrapper(
+      <DownloadReportButton
+        endpoint="test/endpoint/"
+        filename="test_report.csv"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: /download report/i });
+    fireEvent.click(button);
+
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/catalogs/components/DownloadReportButton.tsx
+++ b/src/catalogs/components/DownloadReportButton.tsx
@@ -4,17 +4,34 @@ import { Button } from '@openedx/paragon';
 import { SaveAlt } from '@openedx/paragon/icons';
 
 import messages from '../messages';
+import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 
-interface DownloadReportButtonProps {
-  onClick: () => void;
+export interface DownloadReportButtonProps {
+  endpoint: string;
+  filename: string;
+  successMessage?: string;
   disabled?: boolean;
 }
 
-const DownloadReportButton = ({ onClick, disabled = false }: DownloadReportButtonProps) => {
+const DownloadReportButton = ({
+  endpoint,
+  filename,
+  successMessage,
+  disabled = false,
+}: DownloadReportButtonProps) => {
   const intl = useIntl();
 
+  const downloadReport = useDownloadReport({ endpoint, filename, successMessage });
+
+  const isDisabled = disabled || downloadReport.isPending;
+
   return (
-    <Button iconBefore={SaveAlt} size="sm" onClick={onClick} disabled={disabled}>
+    <Button
+      iconBefore={SaveAlt}
+      size="sm"
+      onClick={() => downloadReport.mutate()}
+      disabled={isDisabled}
+    >
       {intl.formatMessage(messages['corporate.tables.action.download.report'])}
     </Button>
   );

--- a/src/catalogs/components/DownloadReportButton.tsx
+++ b/src/catalogs/components/DownloadReportButton.tsx
@@ -3,8 +3,8 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import { SaveAlt } from '@openedx/paragon/icons';
 
-import messages from '../messages';
 import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
+import messages from '../messages';
 
 export interface DownloadReportButtonProps {
   endpoint: string;

--- a/src/catalogs/components/DownloadReportButton.tsx
+++ b/src/catalogs/components/DownloadReportButton.tsx
@@ -7,13 +7,14 @@ import messages from '../messages';
 
 interface DownloadReportButtonProps {
   onClick: () => void;
+  disabled?: boolean;
 }
 
-const DownloadReportButton = ({ onClick }: DownloadReportButtonProps) => {
+const DownloadReportButton = ({ onClick, disabled = false }: DownloadReportButtonProps) => {
   const intl = useIntl();
 
   return (
-    <Button iconBefore={SaveAlt} size="sm" onClick={onClick}>
+    <Button iconBefore={SaveAlt} size="sm" onClick={onClick} disabled={disabled}>
       {intl.formatMessage(messages['corporate.tables.action.download.report'])}
     </Button>
   );

--- a/src/catalogs/course-detail/components/CourseLearnerList.test.tsx
+++ b/src/catalogs/course-detail/components/CourseLearnerList.test.tsx
@@ -16,12 +16,8 @@ jest.mock('@src/hooks', () => ({
   }),
 }));
 
-jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
-  useDownloadReport: jest.fn(() => ({
-    mutate: jest.fn(),
-    mutateAsync: jest.fn(),
-    isPending: false,
-  })),
+jest.mock('@src/catalogs/components', () => ({
+  DownloadReportButton: jest.fn(() => <button type="button">Download Report</button>),
 }));
 
 jest.mock('../data/hooks', () => ({

--- a/src/catalogs/course-detail/components/CourseLearnerList.test.tsx
+++ b/src/catalogs/course-detail/components/CourseLearnerList.test.tsx
@@ -16,6 +16,14 @@ jest.mock('@src/hooks', () => ({
   }),
 }));
 
+jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
+  useDownloadReport: jest.fn(() => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  })),
+}));
+
 jest.mock('../data/hooks', () => ({
   useCourseLearners: jest.fn().mockReturnValue({
     isLoading: false,

--- a/src/catalogs/course-detail/components/CourseLearnerList.tsx
+++ b/src/catalogs/course-detail/components/CourseLearnerList.tsx
@@ -8,6 +8,7 @@ import {
 import { usePagination, useTableSortFilter } from '@src/hooks';
 
 import { DownloadReportButton } from '@src/catalogs/components';
+import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCourseLearners } from '../data/hooks';
 
 import messages from '../messages';
@@ -33,7 +34,14 @@ const CourseLernerList = ({ catalogId, courseId }) => {
     isLoading,
   } = useCourseLearners(catalogId, courseId, pageIndex + 1, pageSize, ordering, searchParams.search);
 
-  const handleReportCreation = () => {}; // TODO implement report logic once the API is updated.
+  const downloadCourseEnrollmentsReport = useDownloadReport({
+    endpoint: `manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`,
+    filename: 'course_enrollments_report.csv',
+  });
+
+  const handleReportCreation = () => {
+    downloadCourseEnrollmentsReport.mutate();
+  };
 
   return (
     <DataTable
@@ -51,7 +59,7 @@ const CourseLernerList = ({ catalogId, courseId }) => {
       fetchData={fetchData}
       pageCount={pageCount}
       tableActions={[
-        <DownloadReportButton onClick={handleReportCreation} />,
+        <DownloadReportButton onClick={handleReportCreation} disabled={downloadCourseEnrollmentsReport.isPending} />,
       ]}
       itemCount={count}
       data={results}

--- a/src/catalogs/course-detail/components/CourseLearnerList.tsx
+++ b/src/catalogs/course-detail/components/CourseLearnerList.tsx
@@ -12,6 +12,11 @@ import { useCourseLearners } from '../data/hooks';
 
 import messages from '../messages';
 
+const COURSE_ENROLLMENT_REPORT_CONFIG = (catalogId: string, courseId: string) => ({
+  endpoint: `manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`,
+  filename: 'course_enrollments_report.csv',
+});
+
 const searchIds = ['fullName', 'email'];
 const filterMappings = searchIds.reduce((prev, curr) => ({
   ...prev, [curr]: 'search',
@@ -50,8 +55,7 @@ const CourseLernerList = ({ catalogId, courseId }) => {
       pageCount={pageCount}
       tableActions={[
         <DownloadReportButton
-          endpoint={`manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`}
-          filename="course_enrollments_report.csv"
+          {...COURSE_ENROLLMENT_REPORT_CONFIG(catalogId, courseId)}
         />,
       ]}
       itemCount={count}

--- a/src/catalogs/course-detail/components/CourseLearnerList.tsx
+++ b/src/catalogs/course-detail/components/CourseLearnerList.tsx
@@ -8,7 +8,6 @@ import {
 import { usePagination, useTableSortFilter } from '@src/hooks';
 
 import { DownloadReportButton } from '@src/catalogs/components';
-import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCourseLearners } from '../data/hooks';
 
 import messages from '../messages';
@@ -34,15 +33,6 @@ const CourseLernerList = ({ catalogId, courseId }) => {
     isLoading,
   } = useCourseLearners(catalogId, courseId, pageIndex + 1, pageSize, ordering, searchParams.search);
 
-  const downloadCourseEnrollmentsReport = useDownloadReport({
-    endpoint: `manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`,
-    filename: 'course_enrollments_report.csv',
-  });
-
-  const handleReportCreation = () => {
-    downloadCourseEnrollmentsReport.mutate();
-  };
-
   return (
     <DataTable
       isLoading={isLoading}
@@ -59,7 +49,10 @@ const CourseLernerList = ({ catalogId, courseId }) => {
       fetchData={fetchData}
       pageCount={pageCount}
       tableActions={[
-        <DownloadReportButton onClick={handleReportCreation} disabled={downloadCourseEnrollmentsReport.isPending} />,
+        <DownloadReportButton
+          endpoint={`manage/catalogs/${catalogId}/courses/${courseId}/enrollments/`}
+          filename="course_enrollments_report.csv"
+        />,
       ]}
       itemCount={count}
       data={results}

--- a/src/catalogs/course-list/components/CourseList.test.tsx
+++ b/src/catalogs/course-list/components/CourseList.test.tsx
@@ -21,7 +21,13 @@ jest.mock('wouter', () => ({
   useParams: () => ({ partnerSlug: 'partner1', catalogSlug: 'catalog1' }),
 }));
 
-jest.mock('../data/hooks');
+jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
+  useDownloadReport: () => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
 
 const mockCourses = [
   {

--- a/src/catalogs/course-list/components/CourseList.test.tsx
+++ b/src/catalogs/course-list/components/CourseList.test.tsx
@@ -21,12 +21,9 @@ jest.mock('wouter', () => ({
   useParams: () => ({ partnerSlug: 'partner1', catalogSlug: 'catalog1' }),
 }));
 
-jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
-  useDownloadReport: () => ({
-    mutate: jest.fn(),
-    mutateAsync: jest.fn(),
-    isPending: false,
-  }),
+jest.mock('@src/catalogs/components', () => ({
+  DownloadReportButton: jest.fn(() => <button type="button">Download Report</button>),
+  CourseAddModal: jest.fn(() => null),
 }));
 
 jest.mock('../data/hooks', () => ({

--- a/src/catalogs/course-list/components/CourseList.test.tsx
+++ b/src/catalogs/course-list/components/CourseList.test.tsx
@@ -29,6 +29,14 @@ jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
   }),
 }));
 
+jest.mock('../data/hooks', () => ({
+  useCatalogCourses: jest.fn(),
+  useDeleteCatalogCourse: jest.fn(),
+  useAvailableCourses: jest.fn(),
+  useAddCoursesToCatalog: jest.fn(),
+  useUpdateCatalogCourse: jest.fn(),
+}));
+
 const mockCourses = [
   {
     id: 1,

--- a/src/catalogs/course-list/components/CourseList.tsx
+++ b/src/catalogs/course-list/components/CourseList.tsx
@@ -11,7 +11,6 @@ import { useNavigate, usePagination, useTableSortFilter } from '@src/hooks';
 import { ActionItem, SearchFilter, TableFooter } from '@src/components/Table';
 
 import { DownloadReportButton } from '@src/catalogs/components';
-import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useNotification } from '@src/notification';
 import { useCatalogCourses, useUpdateCatalogCourse } from '../data/hooks';
 import CourseAddModal from './CourseAddModal';
@@ -97,10 +96,6 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
   } = useCatalogCourses(catalogId!, pageIndex + 1, pageSize, ordering, searchParams.search);
 
   const updateCatalogCourse = useUpdateCatalogCourse();
-  const downloadCoursesReport = useDownloadReport({
-    endpoint: `manage/catalogs/${catalogId}/courses/`,
-    filename: 'courses_report.csv',
-  });
 
   const positions = Array.from({ length: count || 0 }, (_, i) => i);
   const formatDate = (date: string | null) => {
@@ -141,9 +136,6 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
     );
   };
 
-  const handleReportCreation = () => {
-    downloadCoursesReport.mutate();
-  };
   return (
     <>
       <DataTable
@@ -165,7 +157,10 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
         pageCount={pageCount}
         data={courses}
         tableActions={[
-          <DownloadReportButton onClick={handleReportCreation} disabled={downloadCoursesReport.isPending} />,
+          <DownloadReportButton
+            endpoint={`manage/catalogs/${catalogId}/courses/`}
+            filename="courses_report.csv"
+          />,
           <CourseAddModal catalogId={catalogId} />,
         ]}
         bulkActions={[

--- a/src/catalogs/course-list/components/CourseList.tsx
+++ b/src/catalogs/course-list/components/CourseList.tsx
@@ -8,10 +8,11 @@ import {
 import { CellValue, Course } from '@src/types';
 import { paths } from '@src/constants';
 import { useNavigate, usePagination, useTableSortFilter } from '@src/hooks';
-import { useNotification } from '@src/notification';
 import { ActionItem, SearchFilter, TableFooter } from '@src/components/Table';
 
 import { DownloadReportButton } from '@src/catalogs/components';
+import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
+import { useNotification } from '@src/notification';
 import { useCatalogCourses, useUpdateCatalogCourse } from '../data/hooks';
 import CourseAddModal from './CourseAddModal';
 import CourseDeleteModal from './CourseDeleteModal';
@@ -96,6 +97,10 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
   } = useCatalogCourses(catalogId!, pageIndex + 1, pageSize, ordering, searchParams.search);
 
   const updateCatalogCourse = useUpdateCatalogCourse();
+  const downloadCoursesReport = useDownloadReport({
+    endpoint: `manage/catalogs/${catalogId}/courses/`,
+    filename: 'courses_report.csv',
+  });
 
   const positions = Array.from({ length: count || 0 }, (_, i) => i);
   const formatDate = (date: string | null) => {
@@ -136,7 +141,9 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
     );
   };
 
-  const handleReportCreation = () => {}; // TODO implement once the backend is updated.
+  const handleReportCreation = () => {
+    downloadCoursesReport.mutate();
+  };
   return (
     <>
       <DataTable
@@ -158,7 +165,7 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
         pageCount={pageCount}
         data={courses}
         tableActions={[
-          <DownloadReportButton onClick={handleReportCreation} />,
+          <DownloadReportButton onClick={handleReportCreation} disabled={downloadCoursesReport.isPending} />,
           <CourseAddModal catalogId={catalogId} />,
         ]}
         bulkActions={[

--- a/src/catalogs/course-list/components/CourseList.tsx
+++ b/src/catalogs/course-list/components/CourseList.tsx
@@ -18,6 +18,11 @@ import CourseDeleteModal from './CourseDeleteModal';
 
 import messages from '../messages';
 
+const COURSES_REPORT_CONFIG = (catalogId: string) => ({
+  endpoint: `manage/catalogs/${catalogId}/courses/`,
+  filename: 'courses_report.csv',
+});
+
 type CoursesCell = CellValue<Course>;
 
 interface CoursesListProps {
@@ -157,10 +162,7 @@ const CoursesList = ({ catalogId, catalogName }: CoursesListProps) => {
         pageCount={pageCount}
         data={courses}
         tableActions={[
-          <DownloadReportButton
-            endpoint={`manage/catalogs/${catalogId}/courses/`}
-            filename="courses_report.csv"
-          />,
+          <DownloadReportButton {...COURSES_REPORT_CONFIG(catalogId!)} />,
           <CourseAddModal catalogId={catalogId} />,
         ]}
         bulkActions={[

--- a/src/catalogs/enrollment-list/components/EnrollmentList.test.tsx
+++ b/src/catalogs/enrollment-list/components/EnrollmentList.test.tsx
@@ -10,12 +10,9 @@ jest.mock('@src/hooks', () => ({
   useTableSortFilter: jest.fn(),
 }));
 
-jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
-  useDownloadReport: jest.fn(() => ({
-    mutate: jest.fn(),
-    mutateAsync: jest.fn(),
-    isPending: false,
-  })),
+jest.mock('@src/catalogs/components', () => ({
+  DownloadReportButton: jest.fn(() => <button type="button">Download Report</button>),
+  InviteLearnerAction: jest.fn(() => <button type="button">Invite Learner</button>),
 }));
 
 jest.mock('../data/hooks', () => ({

--- a/src/catalogs/enrollment-list/components/EnrollmentList.test.tsx
+++ b/src/catalogs/enrollment-list/components/EnrollmentList.test.tsx
@@ -10,6 +10,14 @@ jest.mock('@src/hooks', () => ({
   useTableSortFilter: jest.fn(),
 }));
 
+jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
+  useDownloadReport: jest.fn(() => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  })),
+}));
+
 jest.mock('../data/hooks', () => ({
   useCatalogEnrollments: jest.fn(),
   useInviteLearners: jest.fn(() => ({

--- a/src/catalogs/enrollment-list/components/EnrollmentList.tsx
+++ b/src/catalogs/enrollment-list/components/EnrollmentList.tsx
@@ -9,6 +9,7 @@ import { usePagination, useTableSortFilter } from '@src/hooks';
 import { InviteLearnerAction } from '@src/catalogs/invite-learners';
 
 import { DownloadReportButton } from '@src/catalogs/components';
+import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCatalogEnrollments } from '../data/hooks';
 import { dateFormat } from '../../utils';
 
@@ -58,7 +59,14 @@ const EnrollmentsList = ({ catalogId }) => {
     active: searchParams.active,
   });
 
-  const handleReportCreation = () => {}; // TODO implement once the backend is updated.
+  const downloadEnrollmentsReport = useDownloadReport({
+    endpoint: `manage/catalogs/${catalogId}/enrollments/`,
+    filename: 'enrollments_report.csv',
+  });
+
+  const handleReportCreation = () => {
+    downloadEnrollmentsReport.mutate();
+  };
 
   return (
     <DataTable
@@ -79,7 +87,7 @@ const EnrollmentsList = ({ catalogId }) => {
       fetchData={fetchData}
       pageCount={data?.numPages || 0}
       tableActions={[
-        <DownloadReportButton onClick={handleReportCreation} />,
+        <DownloadReportButton onClick={handleReportCreation} disabled={downloadEnrollmentsReport.isPending} />,
         <InviteLearnerAction catalogId={catalogId} />,
       ]}
       itemCount={data?.count || 0}

--- a/src/catalogs/enrollment-list/components/EnrollmentList.tsx
+++ b/src/catalogs/enrollment-list/components/EnrollmentList.tsx
@@ -14,6 +14,11 @@ import { dateFormat } from '../../utils';
 
 import messages from '../messages';
 
+const ENROLLMENTS_REPORT_CONFIG = (catalogId: string) => ({
+  endpoint: `manage/catalogs/${catalogId}/enrollments/`,
+  filename: 'enrollments_report.csv',
+});
+
 const CourseNameCell = ({ row }) => (
   <div className="small">
     <span className="d-block font-weight-bold truncate-1-line">
@@ -77,10 +82,7 @@ const EnrollmentsList = ({ catalogId }) => {
       fetchData={fetchData}
       pageCount={data?.numPages || 0}
       tableActions={[
-        <DownloadReportButton
-          endpoint={`manage/catalogs/${catalogId}/enrollments/`}
-          filename="enrollments_report.csv"
-        />,
+        <DownloadReportButton {...ENROLLMENTS_REPORT_CONFIG(catalogId)} />,
         <InviteLearnerAction catalogId={catalogId} />,
       ]}
       itemCount={data?.count || 0}

--- a/src/catalogs/enrollment-list/components/EnrollmentList.tsx
+++ b/src/catalogs/enrollment-list/components/EnrollmentList.tsx
@@ -9,7 +9,6 @@ import { usePagination, useTableSortFilter } from '@src/hooks';
 import { InviteLearnerAction } from '@src/catalogs/invite-learners';
 
 import { DownloadReportButton } from '@src/catalogs/components';
-import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCatalogEnrollments } from '../data/hooks';
 import { dateFormat } from '../../utils';
 
@@ -59,15 +58,6 @@ const EnrollmentsList = ({ catalogId }) => {
     active: searchParams.active,
   });
 
-  const downloadEnrollmentsReport = useDownloadReport({
-    endpoint: `manage/catalogs/${catalogId}/enrollments/`,
-    filename: 'enrollments_report.csv',
-  });
-
-  const handleReportCreation = () => {
-    downloadEnrollmentsReport.mutate();
-  };
-
   return (
     <DataTable
       isLoading={isLoading}
@@ -87,7 +77,10 @@ const EnrollmentsList = ({ catalogId }) => {
       fetchData={fetchData}
       pageCount={data?.numPages || 0}
       tableActions={[
-        <DownloadReportButton onClick={handleReportCreation} disabled={downloadEnrollmentsReport.isPending} />,
+        <DownloadReportButton
+          endpoint={`manage/catalogs/${catalogId}/enrollments/`}
+          filename="enrollments_report.csv"
+        />,
         <InviteLearnerAction catalogId={catalogId} />,
       ]}
       itemCount={data?.count || 0}

--- a/src/catalogs/hooks/useDownloadReport.ts
+++ b/src/catalogs/hooks/useDownloadReport.ts
@@ -1,0 +1,55 @@
+import { useMutation } from '@tanstack/react-query';
+import { logError } from '@edx/frontend-platform/logging';
+import { downloadBlob, downloadReport } from '@src/catalogs/utils';
+import { useNotification } from '@src/notification';
+
+export interface DownloadReportConfig {
+  endpoint: string;
+  filename: string;
+}
+
+export interface UseDownloadReportOptions {
+  endpoint: string;
+  filename: string;
+  successMessage?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Generic hook for downloading CSV reports.
+ *
+ * This hook provides a reusable way to trigger file downloads
+ * across the application. Each report type just needs to provide
+ * the endpoint and filename.
+ *
+ * @example
+ * ```ts
+ * const downloadCoursesReport = useDownloadReport({
+ *   endpoint: `manage/catalogs/${catalogId}/courses/`,
+ *   filename: 'courses_report.csv',
+ * });
+ *
+ * // Usage:
+ * downloadCoursesReport.mutate();
+ * ```
+ */
+export const useDownloadReport = ({
+  endpoint,
+  filename,
+  successMessage = 'Report downloaded successfully',
+  errorMessage = 'Failed to download report',
+}: UseDownloadReportOptions) => {
+  const { showNotification } = useNotification();
+
+  return useMutation({
+    mutationFn: async () => downloadReport(endpoint, filename),
+    onSuccess: ({ blob }) => {
+      downloadBlob(blob, filename);
+      showNotification(successMessage, 'success');
+    },
+    onError: (error) => {
+      logError(error);
+      showNotification(errorMessage, 'error');
+    },
+  });
+};

--- a/src/catalogs/learner-list/components/LearnerList.test.tsx
+++ b/src/catalogs/learner-list/components/LearnerList.test.tsx
@@ -12,6 +12,14 @@ jest.mock('@src/hooks', () => ({
   useTableSortFilter: jest.fn(),
 }));
 
+jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
+  useDownloadReport: jest.fn(() => ({
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  })),
+}));
+
 jest.mock('../data/hooks', () => ({
   useCatalogLearners: jest.fn(),
   useRemoveLearners: jest.fn(() => ({

--- a/src/catalogs/learner-list/components/LearnerList.test.tsx
+++ b/src/catalogs/learner-list/components/LearnerList.test.tsx
@@ -12,12 +12,9 @@ jest.mock('@src/hooks', () => ({
   useTableSortFilter: jest.fn(),
 }));
 
-jest.mock('@src/catalogs/hooks/useDownloadReport', () => ({
-  useDownloadReport: jest.fn(() => ({
-    mutate: jest.fn(),
-    mutateAsync: jest.fn(),
-    isPending: false,
-  })),
+jest.mock('@src/catalogs/components', () => ({
+  DownloadReportButton: jest.fn(() => <button type="button">Download Report</button>),
+  InviteLearnerAction: jest.fn(() => <button type="button">Invite Learner</button>),
 }));
 
 jest.mock('../data/hooks', () => ({

--- a/src/catalogs/learner-list/components/LearnerList.tsx
+++ b/src/catalogs/learner-list/components/LearnerList.tsx
@@ -18,6 +18,11 @@ import LearnerDeleteModal from './LearnerDeleteModal';
 
 import messages from '../messages';
 
+const LEARNERS_REPORT_CONFIG = (catalogId: string) => ({
+  endpoint: `manage/catalogs/${catalogId}/learners/`,
+  filename: 'learners_report.csv',
+});
+
 const TableAction = ({
   catalogId,
 }: {
@@ -25,10 +30,7 @@ const TableAction = ({
 }) => (
   <>
     <InviteLearnerAction catalogId={catalogId} />
-    <DownloadReportButton
-      endpoint={`manage/catalogs/${catalogId}/learners/`}
-      filename="learners_report.csv"
-    />
+    <DownloadReportButton {...LEARNERS_REPORT_CONFIG(catalogId!)} />
   </>
 );
 

--- a/src/catalogs/learner-list/components/LearnerList.tsx
+++ b/src/catalogs/learner-list/components/LearnerList.tsx
@@ -13,7 +13,6 @@ import { usePagination, useTableSortFilter } from '@src/hooks';
 import { InviteLearnerAction } from '@src/catalogs/invite-learners';
 import { DownloadReportButton } from '@src/catalogs/components';
 import { dateFormat } from '@src/catalogs/utils';
-import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCatalogLearners } from '../data/hooks';
 import LearnerDeleteModal from './LearnerDeleteModal';
 
@@ -21,16 +20,15 @@ import messages from '../messages';
 
 const TableAction = ({
   catalogId,
-  onDownloadReport,
-  isDownloadPending,
 }: {
   catalogId: string;
-  onDownloadReport: () => void;
-  isDownloadPending?: boolean;
 }) => (
   <>
     <InviteLearnerAction catalogId={catalogId} />
-    <DownloadReportButton onClick={onDownloadReport} disabled={isDownloadPending} />
+    <DownloadReportButton
+      endpoint={`manage/catalogs/${catalogId}/learners/`}
+      filename="learners_report.csv"
+    />
   </>
 );
 
@@ -95,11 +93,6 @@ const LearnerList = ({ catalogId, catalogName }) => {
     active: searchParams.active,
   });
 
-  const downloadLearnersReport = useDownloadReport({
-    endpoint: `manage/catalogs/${catalogId}/learners/`,
-    filename: 'learners_report.csv',
-  });
-
   const tableActions = [{
     type: 'delete',
     onClick: (learner: Learner) => {
@@ -107,10 +100,6 @@ const LearnerList = ({ catalogId, catalogName }) => {
       openDeleteModal();
     },
   }];
-
-  const handleReportCreation = () => {
-    downloadLearnersReport.mutate();
-  };
 
   return (
     <>
@@ -133,11 +122,7 @@ const LearnerList = ({ catalogId, catalogName }) => {
         fetchData={fetchData}
         pageCount={data?.numPages || 0}
         tableActions={[
-          <TableAction
-            catalogId={catalogId!}
-            onDownloadReport={handleReportCreation}
-            isDownloadPending={downloadLearnersReport.isPending}
-          />,
+          <TableAction catalogId={catalogId!} />,
         ]}
         bulkActions={[
           <BulkAction setRowsForDelete={setSelectedRowsForDelete} openDeleteModal={openDeleteModal} />,

--- a/src/catalogs/learner-list/components/LearnerList.tsx
+++ b/src/catalogs/learner-list/components/LearnerList.tsx
@@ -10,25 +10,29 @@ import {
 } from '@src/components/Table/';
 import { usePagination, useTableSortFilter } from '@src/hooks';
 
-import { SaveAlt } from '@openedx/paragon/icons';
 import { InviteLearnerAction } from '@src/catalogs/invite-learners';
+import { DownloadReportButton } from '@src/catalogs/components';
 import { dateFormat } from '@src/catalogs/utils';
+import { useDownloadReport } from '@src/catalogs/hooks/useDownloadReport';
 import { useCatalogLearners } from '../data/hooks';
 import LearnerDeleteModal from './LearnerDeleteModal';
 
 import messages from '../messages';
 
-const TableAction = ({ catalogId }: { catalogId: string }) => {
-  const intl = useIntl();
-  return (
-    <>
-      <InviteLearnerAction catalogId={catalogId} />
-      <Button iconBefore={SaveAlt} size="sm">
-        {intl.formatMessage(messages['corporate.catalog.learners.table.action.download.report'])}
-      </Button>
-    </>
-  );
-};
+const TableAction = ({
+  catalogId,
+  onDownloadReport,
+  isDownloadPending,
+}: {
+  catalogId: string;
+  onDownloadReport: () => void;
+  isDownloadPending?: boolean;
+}) => (
+  <>
+    <InviteLearnerAction catalogId={catalogId} />
+    <DownloadReportButton onClick={onDownloadReport} disabled={isDownloadPending} />
+  </>
+);
 
 type BulkActionProps = {
   selectedFlatRows?: any[];
@@ -91,6 +95,11 @@ const LearnerList = ({ catalogId, catalogName }) => {
     active: searchParams.active,
   });
 
+  const downloadLearnersReport = useDownloadReport({
+    endpoint: `manage/catalogs/${catalogId}/learners/`,
+    filename: 'learners_report.csv',
+  });
+
   const tableActions = [{
     type: 'delete',
     onClick: (learner: Learner) => {
@@ -98,6 +107,10 @@ const LearnerList = ({ catalogId, catalogName }) => {
       openDeleteModal();
     },
   }];
+
+  const handleReportCreation = () => {
+    downloadLearnersReport.mutate();
+  };
 
   return (
     <>
@@ -120,7 +133,11 @@ const LearnerList = ({ catalogId, catalogName }) => {
         fetchData={fetchData}
         pageCount={data?.numPages || 0}
         tableActions={[
-          <TableAction catalogId={catalogId!} />,
+          <TableAction
+            catalogId={catalogId!}
+            onDownloadReport={handleReportCreation}
+            isDownloadPending={downloadLearnersReport.isPending}
+          />,
         ]}
         bulkActions={[
           <BulkAction setRowsForDelete={setSelectedRowsForDelete} openDeleteModal={openDeleteModal} />,

--- a/src/catalogs/utils.ts
+++ b/src/catalogs/utils.ts
@@ -1,3 +1,6 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getCorporateApi } from '@src/constants';
+
 export const dateFormat = (isoDateString: string | null) => {
   if (!isoDateString) {
     return null;
@@ -7,4 +10,37 @@ export const dateFormat = (isoDateString: string | null) => {
   const formatted = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} `
         + `${pad(date.getHours())}:${pad(date.getMinutes())}`;
   return formatted;
+};
+
+/**
+ * Utility function to trigger a blob download in the browser.
+ *
+ * @param blob - The blob to download
+ * @param filename - The name of the file to save as
+ */
+export const downloadBlob = (blob: Blob, filename: string) => {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+};
+
+/**
+ * Generic report downloader for CSV reports.
+ *
+ * @param endpoint - The API endpoint path (e.g., 'manage/catalogs/123/courses/')
+ * @param filename - The filename to save as (e.g., 'courses_report.csv')
+ * @returns Promise with blob and filename
+ */
+export const downloadReport = async (endpoint: string, filename: string) => {
+  const config = { responseType: 'blob' as const };
+  const url = new URL(getCorporateApi(endpoint));
+  url.searchParams.append('format', 'csv');
+
+  const { data } = await getAuthenticatedHttpClient().get(url.toString(), config);
+  return { blob: data, filename };
 };


### PR DESCRIPTION
This PR implements CSV report download functionality across 4 modules (courses, enrollments, learners, course-enrollments) with a reusable generic hook to avoid code duplication.

### Screencast
[Screencast from 16-03-26 16:16:41.webm](https://github.com/user-attachments/assets/3085d558-26f8-4b35-8841-dcb6a36b871c)
