### PR TITLE
fix: add i18n for static tabs titles in add courses modal

### DIFF
--- a/src/catalogs/course-list/components/CourseAddModal/AddCourseModal.tsx
+++ b/src/catalogs/course-list/components/CourseAddModal/AddCourseModal.tsx
@@ -65,7 +65,7 @@ const AddCourseModal = ({ isOpen, onClose, catalogId }: AddCourseModalProps) => 
     >
       <Container className="min-vh-100">
         <Tabs className="mt-4">
-          <Tab eventKey="all" title="Base Catalog Courses">
+          <Tab eventKey="all" title={intl.formatMessage(messages['corporate.courses.modal.add.tab.base'])}>
             {loadingAll ? <Loader />
               : (
                 <AvailableCoursesList
@@ -75,7 +75,7 @@ const AddCourseModal = ({ isOpen, onClose, catalogId }: AddCourseModalProps) => 
                 />
               )}
           </Tab>
-          <Tab eventKey="current" title="My Organization's Courses">
+          <Tab eventKey="current" title={intl.formatMessage(messages['corporate.courses.modal.add.tab.organization'])}>
             {loadingAll ? <Loader />
               : (
                 <AvailableCoursesList

--- a/src/catalogs/course-list/messages.ts
+++ b/src/catalogs/course-list/messages.ts
@@ -78,7 +78,7 @@ const messages = defineMessages({
   },
   'corporate.courses.modal.add.tab.organization': {
     id: 'corporate.courses.modal.add.tab.organization',
-    defaultMessage: 'Organization Courses',
+    defaultMessage: 'My Organization\'s Courses',
     description: 'Tab title for organization courses',
   },
   'corporate.courses.modal.add.button.add': {


### PR DESCRIPTION
### Description

The Tabs title is a static text and is not being translated to Portuguese.

<img width="822" height="477" alt="image" src="https://github.com/user-attachments/assets/e5363709-cd07-4af7-a023-669f088c847f" />


The current PR replaces the static value with the corresponding already available in `messages`. The translations repository update https://github.com/fccn/openedx-translations/pull/7