### PR TITLE
feat: add Invitations tab and seat breakdown

### DIFF
--- a/src/catalogs/CatalogDetailPage.test.tsx
+++ b/src/catalogs/CatalogDetailPage.test.tsx
@@ -94,6 +94,16 @@ jest.mock('@src/catalogs/invite-learners/data/hooks', () => ({
   })),
 }));
 
+jest.mock('@src/catalogs/invitation-list/data/hooks', () => ({
+  useCatalogInvitations: jest.fn(() => ({
+    data: { results: [], count: 0, numPages: 1 },
+    isLoading: false,
+  })),
+  useResendInvitation: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
+  useCancelInvitation: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
+  queryKey: { catalogInvitations: jest.fn(() => []) },
+}));
+
 jest.mock('@src/notification', () => ({
   useNotification: () => ({
     showNotification: jest.fn(),
@@ -145,24 +155,25 @@ describe('CatalogDetailPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Test Catalog')).toBeInTheDocument();
-      expect(screen.getByText('Available Seats')).toBeInTheDocument();
-      expect(screen.getByText('50 / 100')).toBeInTheDocument();
+      expect(screen.getByText('Seats')).toBeInTheDocument();
+      expect(screen.getByText('50 accepted · 0 pending · 50 free / 100')).toBeInTheDocument();
       expect(screen.getByText('Learners', { selector: 'span' })).toBeInTheDocument();
       expect(screen.getByText('75')).toBeInTheDocument();
     });
   });
 
-  it('renders tabs for courses, learners, and enrollments', async () => {
+  it('renders tabs for courses, learners, enrollments, and invitations', async () => {
     renderCatalogDetailPage();
 
     await waitFor(() => {
       const tabElements = screen.getAllByRole('tab');
       // Filter out the "More..." dropdown tab
       const contentTabs = tabElements.filter(tab => !tab.textContent?.includes('More...'));
-      expect(contentTabs).toHaveLength(3);
+      expect(contentTabs).toHaveLength(4);
       expect(contentTabs[0]).toHaveTextContent('Courses');
       expect(contentTabs[1]).toHaveTextContent('Learners');
       expect(contentTabs[2]).toHaveTextContent('Enrollments');
+      expect(contentTabs[3]).toHaveTextContent('Invitations');
     });
   });
 

--- a/src/catalogs/CatalogDetailPage.test.tsx
+++ b/src/catalogs/CatalogDetailPage.test.tsx
@@ -172,8 +172,8 @@ describe('CatalogDetailPage', () => {
       expect(contentTabs).toHaveLength(4);
       expect(contentTabs[0]).toHaveTextContent('Courses');
       expect(contentTabs[1]).toHaveTextContent('Learners');
-      expect(contentTabs[2]).toHaveTextContent('Enrollments');
-      expect(contentTabs[3]).toHaveTextContent('Invitations');
+      expect(contentTabs[2]).toHaveTextContent('Invitations');
+      expect(contentTabs[3]).toHaveTextContent('Enrollments');
     });
   });
 

--- a/src/catalogs/CatalogDetailPage.tsx
+++ b/src/catalogs/CatalogDetailPage.tsx
@@ -12,6 +12,7 @@ import { paths } from '@src/constants';
 import AppLayout from '@src/components/AppLayout';
 import { CatalogSettingsModal } from './catalog-settings';
 import { LearnerList } from './learner-list';
+import { InvitationList } from './invitation-list';
 import { EnrollmentList } from './enrollment-list';
 import { CourseList } from './course-list';
 
@@ -46,7 +47,10 @@ const CatalogDetailPage = () => {
                 copyableDescription: true,
               }}
               info={[
-                { title: intl.formatMessage(messages['corporate.catalog.header.info.seats']), value: `${catalogDetails.userLimit - catalogDetails.activeLearners} / ${catalogDetails.userLimit}` },
+                {
+                  title: intl.formatMessage(messages['corporate.catalog.header.info.seats']),
+                  value: `${catalogDetails.activeLearners} ${intl.formatMessage(messages['corporate.catalog.header.info.seats.accepted'])} · ${catalogDetails.pendingInvitations ?? 0} ${intl.formatMessage(messages['corporate.catalog.header.info.seats.pending'])} · ${Math.max(0, catalogDetails.userLimit - catalogDetails.activeLearners - (catalogDetails.pendingInvitations ?? 0))} ${intl.formatMessage(messages['corporate.catalog.header.info.seats.free'])} / ${catalogDetails.userLimit}`,
+                },
                 { title: intl.formatMessage(messages['corporate.catalog.header.info.learners']), value: catalogDetails.totalLearners },
                 { title: intl.formatMessage(messages['corporate.catalog.header.info.courses']), value: catalogDetails.courses },
                 { title: intl.formatMessage(messages['corporate.catalog.header.info.enrollments']), value: catalogDetails.enrollments },
@@ -66,6 +70,9 @@ const CatalogDetailPage = () => {
               </Tab>
               <Tab eventKey="learners" title={intl.formatMessage(messages['corporate.catalog.detail.page.tab.learners'])} alt="Learners Tab">
                 <LearnerList catalogId={catalogDetails.id} catalogName={catalogDetails.name} />
+              </Tab>
+              <Tab eventKey="invitations" title={intl.formatMessage(messages['corporate.catalog.detail.page.tab.invitations'])} alt="Invitations Tab">
+                <InvitationList catalogId={catalogDetails.id} catalogName={catalogDetails.name} />
               </Tab>
               <Tab eventKey="enrollments" title={intl.formatMessage(messages['corporate.catalog.detail.page.tab.enrollments'])} alt="Enrollments Tab">
                 <EnrollmentList catalogId={catalogDetails.id} />

--- a/src/catalogs/CatalogDetailPage.tsx
+++ b/src/catalogs/CatalogDetailPage.tsx
@@ -72,7 +72,7 @@ const CatalogDetailPage = () => {
                 <LearnerList catalogId={catalogDetails.id} catalogName={catalogDetails.name} />
               </Tab>
               <Tab eventKey="invitations" title={intl.formatMessage(messages['corporate.catalog.detail.page.tab.invitations'])} alt="Invitations Tab">
-                <InvitationList catalogId={catalogDetails.id} catalogName={catalogDetails.name} />
+                <InvitationList catalogId={catalogDetails.id} />
               </Tab>
               <Tab eventKey="enrollments" title={intl.formatMessage(messages['corporate.catalog.detail.page.tab.enrollments'])} alt="Enrollments Tab">
                 <EnrollmentList catalogId={catalogDetails.id} />

--- a/src/catalogs/invitation-list/components/InvitationCancelModal.test.tsx
+++ b/src/catalogs/invitation-list/components/InvitationCancelModal.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWrapper } from '@src/setupTest';
+import InvitationCancelModal from './InvitationCancelModal';
+import * as hooks from '../data/hooks';
+
+jest.mock('../data/hooks', () => ({
+  useCancelInvitation: jest.fn(),
+}));
+
+const mockUseCancelInvitation = hooks.useCancelInvitation as jest.Mock;
+
+const mockInvitation = {
+  id: 1,
+  inviteEmail: 'to_cancel@example.com',
+  status: 'pending' as const,
+  statusDisplay: 'Sent',
+  isRegistered: false,
+  username: null,
+  fullName: null,
+  invitedAt: '2024-01-01T10:00:00Z',
+  acceptedAt: null,
+  declinedAt: null,
+  cancelledAt: null,
+  removedAt: null,
+  invitedBy: 'manager_user',
+};
+
+describe('InvitationCancelModal', () => {
+  const mockOnClose = jest.fn();
+  const mockMutate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMutate.mockImplementation((_vars, options) => {
+      if (options?.onSuccess) { options.onSuccess(); }
+    });
+    mockUseCancelInvitation.mockReturnValue({ mutate: mockMutate, isPending: false });
+  });
+
+  it('renders modal when isOpen is true', () => {
+    renderWrapper(
+      <InvitationCancelModal
+        isOpen
+        onClose={mockOnClose}
+        catalogId="test-catalog"
+        invitation={mockInvitation}
+      />,
+    );
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Cancel Invitation');
+  });
+
+  it('shows confirmation message with email', () => {
+    renderWrapper(
+      <InvitationCancelModal
+        isOpen
+        onClose={mockOnClose}
+        catalogId="test-catalog"
+        invitation={mockInvitation}
+      />,
+    );
+    expect(screen.getByText(/to_cancel@example\.com/)).toBeInTheDocument();
+  });
+
+  it('calls cancelInvitation on confirm', async () => {
+    const user = userEvent.setup();
+    renderWrapper(
+      <InvitationCancelModal
+        isOpen
+        onClose={mockOnClose}
+        catalogId="test-catalog"
+        invitation={mockInvitation}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel Invitation' }));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { catalogId: 'test-catalog', invitationId: 1 },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderWrapper(
+      <InvitationCancelModal
+        isOpen={false}
+        onClose={mockOnClose}
+        catalogId="test-catalog"
+        invitation={mockInvitation}
+      />,
+    );
+    expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+  });
+});

--- a/src/catalogs/invitation-list/components/InvitationCancelModal.tsx
+++ b/src/catalogs/invitation-list/components/InvitationCancelModal.tsx
@@ -1,0 +1,61 @@
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@openedx/paragon';
+import ModalLayout from '@src/components/ModalLayout';
+import { useNotification } from '@src/notification';
+import { CatalogInvitation } from '@src/types';
+import { useCancelInvitation } from '../data/hooks';
+import messages from '../messages';
+
+interface InvitationCancelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  catalogId: string;
+  invitation: CatalogInvitation | null;
+}
+
+const InvitationCancelModal = ({
+  isOpen,
+  onClose,
+  catalogId,
+  invitation,
+}: InvitationCancelModalProps) => {
+  const intl = useIntl();
+  const { showNotification } = useNotification();
+  const cancelMutation = useCancelInvitation();
+
+  const handleCancel = () => {
+    if (!invitation) { return; }
+    cancelMutation.mutate({ catalogId, invitationId: invitation.id }, {
+      onSuccess: () => {
+        showNotification(intl.formatMessage(messages['corporate.catalog.invitations.modal.cancel.success']), 'success');
+        onClose();
+      },
+      onError: () => {
+        showNotification(intl.formatMessage(messages['corporate.catalog.invitations.modal.cancel.error']), 'error');
+      },
+    });
+  };
+
+  return (
+    <ModalLayout
+      title={intl.formatMessage(messages['corporate.catalog.invitations.modal.cancel.title'])}
+      isOpen={isOpen}
+      onClose={onClose}
+      actions={(
+        <Button variant="danger" onClick={handleCancel} disabled={cancelMutation.isPending}>
+          {intl.formatMessage(messages['corporate.catalog.invitations.modal.cancel.action'])}
+        </Button>
+      )}
+    >
+      <Container className="py-4">
+        <p>
+          {intl.formatMessage(messages['corporate.catalog.invitations.modal.cancel.confirmation'], {
+            email: invitation?.inviteEmail || '',
+          })}
+        </p>
+      </Container>
+    </ModalLayout>
+  );
+};
+
+export default InvitationCancelModal;

--- a/src/catalogs/invitation-list/components/InvitationList.test.tsx
+++ b/src/catalogs/invitation-list/components/InvitationList.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { renderWrapper } from '@src/setupTest';
 import * as appHooks from '@src/hooks';
 import * as hooks from '../data/hooks';

--- a/src/catalogs/invitation-list/components/InvitationList.test.tsx
+++ b/src/catalogs/invitation-list/components/InvitationList.test.tsx
@@ -1,0 +1,182 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWrapper } from '@src/setupTest';
+import * as appHooks from '@src/hooks';
+import * as hooks from '../data/hooks';
+
+import InvitationList from './InvitationList';
+
+jest.mock('@src/hooks', () => ({
+  useNavigate: jest.fn(),
+  usePagination: jest.fn(),
+  useTableSortFilter: jest.fn(),
+}));
+
+jest.mock('@src/catalogs/components', () => ({
+  DownloadReportButton: jest.fn(() => <button type="button">Download Report</button>),
+}));
+
+jest.mock('../data/hooks', () => ({
+  useCatalogInvitations: jest.fn(),
+  useResendInvitation: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
+  useCancelInvitation: jest.fn(() => ({ mutate: jest.fn(), isPending: false })),
+}));
+
+const mockUsePagination = appHooks.usePagination as jest.Mock;
+const mockUseTableSortFilter = appHooks.useTableSortFilter as jest.Mock;
+const mockUseCatalogInvitations = hooks.useCatalogInvitations as jest.Mock;
+
+const mockPendingInvitation = {
+  id: 1,
+  inviteEmail: 'pending@example.com',
+  status: 'pending',
+  statusDisplay: 'Sent',
+  isRegistered: false,
+  username: null,
+  fullName: null,
+  invitedAt: '2024-01-01T10:00:00Z',
+  acceptedAt: null,
+  declinedAt: null,
+  cancelledAt: null,
+  removedAt: null,
+  invitedBy: 'manager_user',
+};
+
+const mockAcceptedInvitation = {
+  id: 2,
+  inviteEmail: 'accepted@example.com',
+  status: 'accepted',
+  statusDisplay: 'Accepted',
+  isRegistered: true,
+  username: 'accepted_user',
+  fullName: 'Accepted User',
+  invitedAt: '2024-01-01T10:00:00Z',
+  acceptedAt: '2024-01-05T10:00:00Z',
+  declinedAt: null,
+  cancelledAt: null,
+  removedAt: null,
+  invitedBy: 'manager_user',
+};
+
+const mockData = {
+  count: 2,
+  numPages: 1,
+  results: [mockPendingInvitation, mockAcceptedInvitation],
+};
+
+const renderInvitationList = (props = {}) => renderWrapper(
+  <InvitationList catalogId="test-catalog" catalogName="Test Catalog" {...props} />,
+);
+
+describe('InvitationList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePagination.mockReturnValue({
+      pageIndex: 0,
+      pageSize: 10,
+      onPaginationChange: jest.fn(),
+    });
+    mockUseTableSortFilter.mockReturnValue({
+      ordering: '',
+      searchParams: { status: '10' },
+      fetchData: jest.fn(),
+    });
+  });
+
+  it('renders loading state', () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: undefined, isLoading: true });
+    renderInvitationList();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('renders invitation data correctly', async () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: mockData, isLoading: false });
+    renderInvitationList();
+
+    await waitFor(() => {
+      expect(screen.getByText('pending@example.com')).toBeInTheDocument();
+      expect(screen.getByText('accepted@example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Not registered yet" for unregistered invitees', async () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: mockData, isLoading: false });
+    renderInvitationList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Not registered yet')).toBeInTheDocument();
+    });
+  });
+
+  it('shows username for registered invitees', async () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: mockData, isLoading: false });
+    renderInvitationList();
+
+    await waitFor(() => {
+      expect(screen.getByText('accepted_user')).toBeInTheDocument();
+    });
+  });
+
+  it('displays Pending status badge for pending invitations', async () => {
+    mockUseCatalogInvitations.mockReturnValue({
+      data: { count: 1, numPages: 1, results: [mockPendingInvitation] },
+      isLoading: false,
+    });
+    renderInvitationList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+  });
+
+  it('displays Accepted status badge for accepted invitations', async () => {
+    mockUseCatalogInvitations.mockReturnValue({
+      data: { count: 1, numPages: 1, results: [mockAcceptedInvitation] },
+      isLoading: false,
+    });
+    renderInvitationList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Accepted')).toBeInTheDocument();
+    });
+  });
+
+  it('uses pending filter as default', () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: undefined, isLoading: false });
+    renderInvitationList();
+
+    expect(mockUseCatalogInvitations).toHaveBeenCalledWith(
+      expect.objectContaining({ status: '10' }),
+    );
+  });
+
+  it('disables resend and cancel for non-pending rows', async () => {
+    mockUseCatalogInvitations.mockReturnValue({
+      data: { count: 1, numPages: 1, results: [mockAcceptedInvitation] },
+      isLoading: false,
+    });
+    renderInvitationList();
+
+    await waitFor(() => {
+      const resendBtn = screen.getByRole('button', { name: 'Resend' });
+      const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+      expect(resendBtn).toBeDisabled();
+      expect(cancelBtn).toBeDisabled();
+    });
+  });
+
+  it('renders empty state', () => {
+    mockUseCatalogInvitations.mockReturnValue({
+      data: { count: 0, numPages: 0, results: [] },
+      isLoading: false,
+    });
+    renderInvitationList();
+    expect(screen.getByText('No invitations found')).toBeInTheDocument();
+  });
+
+  it('renders download report button', async () => {
+    mockUseCatalogInvitations.mockReturnValue({ data: mockData, isLoading: false });
+    renderInvitationList();
+    expect(screen.getByText('Download Report')).toBeInTheDocument();
+  });
+});

--- a/src/catalogs/invitation-list/components/InvitationList.tsx
+++ b/src/catalogs/invitation-list/components/InvitationList.tsx
@@ -1,0 +1,207 @@
+import { useState, useMemo } from 'react';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Button, DataTable, useToggle, CheckboxFilter, IconButton, OverlayTrigger, Tooltip,
+} from '@openedx/paragon';
+import { Email, Close } from '@openedx/paragon/icons';
+
+import { CatalogInvitation, CellValue } from '@src/types';
+import {
+  FilterStatus, InvitationStatus, SearchFilter, TableFooter,
+} from '@src/components/Table/';
+import { usePagination, useTableSortFilter } from '@src/hooks';
+import { DownloadReportButton } from '@src/catalogs/components';
+import { dateFormat } from '@src/catalogs/utils';
+import { useCatalogInvitations, useResendInvitation } from '../data/hooks';
+import InvitationCancelModal from './InvitationCancelModal';
+import messages from '../messages';
+
+const INVITATIONS_REPORT_CONFIG = (catalogId: string) => ({
+  endpoint: `manage/catalogs/${catalogId}/invitations/`,
+  filename: 'invitations_report.csv',
+});
+
+const searchIds = ['email', 'username'];
+const filterMappings = {
+  ...searchIds.reduce((prev, curr) => ({ ...prev, [curr]: 'search' }), {}),
+  status: 'status',
+};
+
+const InvitationList = ({ catalogId, catalogName }: { catalogId: string; catalogName: string }) => {
+  const intl = useIntl();
+
+  const [isCancelModalOpen, openCancelModal, closeCancelModal] = useToggle(false);
+  const [selectedInvitation, setSelectedInvitation] = useState<CatalogInvitation | null>(null);
+  const { pageIndex, pageSize, onPaginationChange } = usePagination();
+
+  const tableConfig = useMemo(() => ({
+    sortMappings: {
+      invitedAt: 'invited_at',
+      acceptedAt: 'accepted_at',
+      cancelledAt: 'cancelled_at',
+    },
+    filterMappings,
+    onPaginationChange,
+  }), [onPaginationChange]);
+
+  const { ordering, searchParams, fetchData } = useTableSortFilter(tableConfig);
+
+  const { data, isLoading } = useCatalogInvitations({
+    catalogId,
+    pageIndex: pageIndex + 1,
+    pageSize,
+    ordering,
+    search: searchParams.search,
+    status: searchParams.status,
+  });
+
+  const resendMutation = useResendInvitation();
+
+  const handleResend = (invitation: CatalogInvitation) => {
+    resendMutation.mutate({ catalogId, invitationId: invitation.id });
+  };
+
+  const handleCancel = (invitation: CatalogInvitation) => {
+    setSelectedInvitation(invitation);
+    openCancelModal();
+  };
+
+  return (
+    <>
+      <DataTable
+        isLoading={isLoading}
+        isPaginated
+        isFilterable
+        isSortable
+        defaultColumnValues={{ disableFilters: true, disableSortBy: true }}
+        FilterStatusComponent={FilterStatus}
+        initialState={{
+          pageSize,
+          pageIndex,
+          filters: [{ id: 'status', value: ['10'] }],
+        }}
+        manualPagination
+        manualSortBy
+        manualFilters
+        fetchData={fetchData}
+        pageCount={data?.numPages || 0}
+        tableActions={[
+          <DownloadReportButton {...INVITATIONS_REPORT_CONFIG(catalogId)} />,
+        ]}
+        additionalColumns={[
+          {
+            id: 'action',
+            Header: intl.formatMessage(messages['corporate.catalog.table.header.action']),
+            Cell: ({ row }: CellValue<CatalogInvitation>) => {
+              const isPending = row.original.status === 'pending';
+              return (
+                <>
+                  <OverlayTrigger
+                    overlay={<Tooltip id={`resend-${row.original.id}`}>{intl.formatMessage(messages['corporate.catalog.invitations.action.resend'])}</Tooltip>}
+                  >
+                    <IconButton
+                      src={Email}
+                      alt={intl.formatMessage(messages['corporate.catalog.invitations.action.resend'])}
+                      disabled={!isPending}
+                      onClick={isPending ? () => handleResend(row.original) : undefined}
+                    />
+                  </OverlayTrigger>
+                  <OverlayTrigger
+                    overlay={<Tooltip id={`cancel-${row.original.id}`}>{intl.formatMessage(messages['corporate.catalog.invitations.action.cancel'])}</Tooltip>}
+                  >
+                    <IconButton
+                      src={Close}
+                      alt={intl.formatMessage(messages['corporate.catalog.invitations.action.cancel'])}
+                      variant="danger"
+                      disabled={!isPending}
+                      onClick={isPending ? () => handleCancel(row.original) : undefined}
+                    />
+                  </OverlayTrigger>
+                </>
+              );
+            },
+          },
+        ]}
+        itemCount={data?.count || 0}
+        data={data?.results || []}
+        columns={[
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.email']),
+            accessor: 'inviteEmail',
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.name']),
+            accessor: 'username',
+            disableFilters: false,
+            Filter: SearchFilter,
+            meta: { searchIds },
+            Cell: ({ row }: CellValue<CatalogInvitation>) => {
+              const { username, fullName, isRegistered } = row.original;
+              if (!isRegistered) {
+                return <span className="text-muted">{intl.formatMessage(messages['corporate.catalog.invitations.not.registered'])}</span>;
+              }
+              return (
+                <div>
+                  <span className="d-block truncate-1-line">{username}</span>
+                  {fullName && fullName !== username && (
+                    <span className="small text-muted truncate-1-line">{fullName}</span>
+                  )}
+                </div>
+              );
+            },
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.status']),
+            accessor: 'status',
+            disableFilters: false,
+            Cell: InvitationStatus,
+            Filter: CheckboxFilter,
+            filter: 'includesValue',
+            filterChoices: [
+              { value: '10', name: intl.formatMessage(messages['corporate.catalog.invitations.filter.pending']) },
+              { value: '20', name: intl.formatMessage(messages['corporate.catalog.invitations.filter.accepted']) },
+              { value: '30', name: intl.formatMessage(messages['corporate.catalog.invitations.filter.declined']) },
+              { value: '40', name: intl.formatMessage(messages['corporate.catalog.invitations.filter.removed']) },
+              { value: '50', name: intl.formatMessage(messages['corporate.catalog.invitations.filter.cancelled']) },
+            ],
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.invited.at']),
+            accessor: 'invitedAt',
+            disableSortBy: false,
+            Cell: ({ row }) => dateFormat(row.original.invitedAt),
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.accepted.at']),
+            accessor: 'acceptedAt',
+            disableSortBy: false,
+            Cell: ({ row }) => dateFormat(row.original.acceptedAt),
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.cancelled.at']),
+            accessor: 'cancelledAt',
+            disableSortBy: false,
+            Cell: ({ row }) => dateFormat(row.original.cancelledAt),
+          },
+          {
+            Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.invited.by']),
+            accessor: 'invitedBy',
+          },
+        ]}
+      >
+        <DataTable.TableControlBar />
+        <DataTable.Table />
+        <DataTable.EmptyTable content={intl.formatMessage(messages['corporate.catalog.invitations.table.empty.content'])} />
+        <TableFooter />
+      </DataTable>
+      <InvitationCancelModal
+        isOpen={isCancelModalOpen}
+        onClose={closeCancelModal}
+        catalogId={catalogId}
+        invitation={selectedInvitation}
+      />
+    </>
+  );
+};
+
+export default InvitationList;

--- a/src/catalogs/invitation-list/components/InvitationList.tsx
+++ b/src/catalogs/invitation-list/components/InvitationList.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
-  Button, DataTable, useToggle, CheckboxFilter, IconButton, OverlayTrigger, Tooltip,
+  DataTable, useToggle, CheckboxFilter, IconButton, OverlayTrigger, Tooltip,
 } from '@openedx/paragon';
 import { Email, Close } from '@openedx/paragon/icons';
 
@@ -27,7 +27,61 @@ const filterMappings = {
   status: 'status',
 };
 
-const InvitationList = ({ catalogId, catalogName }: { catalogId: string; catalogName: string }) => {
+type ActionCellProps = {
+  row: { original: CatalogInvitation };
+  column: {
+    onResend: (inv: CatalogInvitation) => void;
+    onCancel: (inv: CatalogInvitation) => void;
+  };
+};
+
+const InvitationActionCell = ({ row, column }: ActionCellProps) => {
+  const { formatMessage } = useIntl();
+  const isPending = row.original.status === 'pending';
+  return (
+    <>
+      <OverlayTrigger
+        overlay={<Tooltip id={`resend-${row.original.id}`}>{formatMessage(messages['corporate.catalog.invitations.action.resend'])}</Tooltip>}
+      >
+        <IconButton
+          src={Email}
+          alt={formatMessage(messages['corporate.catalog.invitations.action.resend'])}
+          disabled={!isPending}
+          onClick={isPending ? () => column.onResend(row.original) : undefined}
+        />
+      </OverlayTrigger>
+      <OverlayTrigger
+        overlay={<Tooltip id={`cancel-${row.original.id}`}>{formatMessage(messages['corporate.catalog.invitations.action.cancel'])}</Tooltip>}
+      >
+        <IconButton
+          src={Close}
+          alt={formatMessage(messages['corporate.catalog.invitations.action.cancel'])}
+          variant="danger"
+          disabled={!isPending}
+          onClick={isPending ? () => column.onCancel(row.original) : undefined}
+        />
+      </OverlayTrigger>
+    </>
+  );
+};
+
+const InvitationNameCell = ({ row }: CellValue<CatalogInvitation>) => {
+  const { formatMessage } = useIntl();
+  const { username, fullName, isRegistered } = row.original;
+  if (!isRegistered) {
+    return <span className="text-muted">{formatMessage(messages['corporate.catalog.invitations.not.registered'])}</span>;
+  }
+  return (
+    <div>
+      <span className="d-block truncate-1-line">{username}</span>
+      {fullName && fullName !== username && (
+        <span className="small text-muted truncate-1-line">{fullName}</span>
+      )}
+    </div>
+  );
+};
+
+const InvitationList = ({ catalogId }: { catalogId: string }) => {
   const intl = useIntl();
 
   const [isCancelModalOpen, openCancelModal, closeCancelModal] = useToggle(false);
@@ -92,34 +146,9 @@ const InvitationList = ({ catalogId, catalogName }: { catalogId: string; catalog
           {
             id: 'action',
             Header: intl.formatMessage(messages['corporate.catalog.table.header.action']),
-            Cell: ({ row }: CellValue<CatalogInvitation>) => {
-              const isPending = row.original.status === 'pending';
-              return (
-                <>
-                  <OverlayTrigger
-                    overlay={<Tooltip id={`resend-${row.original.id}`}>{intl.formatMessage(messages['corporate.catalog.invitations.action.resend'])}</Tooltip>}
-                  >
-                    <IconButton
-                      src={Email}
-                      alt={intl.formatMessage(messages['corporate.catalog.invitations.action.resend'])}
-                      disabled={!isPending}
-                      onClick={isPending ? () => handleResend(row.original) : undefined}
-                    />
-                  </OverlayTrigger>
-                  <OverlayTrigger
-                    overlay={<Tooltip id={`cancel-${row.original.id}`}>{intl.formatMessage(messages['corporate.catalog.invitations.action.cancel'])}</Tooltip>}
-                  >
-                    <IconButton
-                      src={Close}
-                      alt={intl.formatMessage(messages['corporate.catalog.invitations.action.cancel'])}
-                      variant="danger"
-                      disabled={!isPending}
-                      onClick={isPending ? () => handleCancel(row.original) : undefined}
-                    />
-                  </OverlayTrigger>
-                </>
-              );
-            },
+            onResend: handleResend,
+            onCancel: handleCancel,
+            Cell: InvitationActionCell,
           },
         ]}
         itemCount={data?.count || 0}
@@ -135,20 +164,7 @@ const InvitationList = ({ catalogId, catalogName }: { catalogId: string; catalog
             disableFilters: false,
             Filter: SearchFilter,
             meta: { searchIds },
-            Cell: ({ row }: CellValue<CatalogInvitation>) => {
-              const { username, fullName, isRegistered } = row.original;
-              if (!isRegistered) {
-                return <span className="text-muted">{intl.formatMessage(messages['corporate.catalog.invitations.not.registered'])}</span>;
-              }
-              return (
-                <div>
-                  <span className="d-block truncate-1-line">{username}</span>
-                  {fullName && fullName !== username && (
-                    <span className="small text-muted truncate-1-line">{fullName}</span>
-                  )}
-                </div>
-              );
-            },
+            Cell: InvitationNameCell,
           },
           {
             Header: intl.formatMessage(messages['corporate.catalog.invitations.table.header.status']),

--- a/src/catalogs/invitation-list/data/api.ts
+++ b/src/catalogs/invitation-list/data/api.ts
@@ -1,0 +1,49 @@
+import { camelCaseObject } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { CatalogInvitation, PaginatedResponse } from '@src/types';
+import { getCorporateApi } from '@src/constants';
+
+export const getCatalogInvitations = async (
+  catalogId: string | number,
+  pageIndex: number,
+  pageSize: number,
+  ordering?: string,
+  search?: string,
+  status?: string,
+): Promise<PaginatedResponse<CatalogInvitation>> => {
+  try {
+    const url = new URL(getCorporateApi(`manage/catalogs/${catalogId}/invitations/`));
+    url.searchParams.append('page', pageIndex.toString());
+    url.searchParams.append('page_size', pageSize.toString());
+    if (ordering) { url.searchParams.append('ordering', ordering); }
+    if (search) { url.searchParams.append('search', search); }
+    if (status) { url.searchParams.append('status', status); }
+    const response = await getAuthenticatedHttpClient().get(url);
+    return camelCaseObject(response.data);
+  } catch (error) {
+    logError(error);
+    return {
+      next: null, previous: null, count: 0, numPages: 0, currentPage: 0, start: 0, results: [],
+    };
+  }
+};
+
+export const resendInvitation = async (
+  catalogId: string | number,
+  invitationId: number,
+): Promise<CatalogInvitation> => {
+  const url = getCorporateApi(`manage/catalogs/${catalogId}/invitations/${invitationId}/resend/`);
+  const response = await getAuthenticatedHttpClient().post(url);
+  return camelCaseObject(response.data);
+};
+
+export const cancelInvitation = async (
+  catalogId: string | number,
+  invitationId: number,
+): Promise<CatalogInvitation> => {
+  const url = getCorporateApi(`manage/catalogs/${catalogId}/invitations/${invitationId}/cancel/`);
+  const response = await getAuthenticatedHttpClient().post(url);
+  return camelCaseObject(response.data);
+};

--- a/src/catalogs/invitation-list/data/hooks.ts
+++ b/src/catalogs/invitation-list/data/hooks.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { appId } from '@src/constants';
-import { queryKey as catalogsQueryKey } from '@src/catalogs/data/hooks';
 import { queryKey as learnersQueryKey } from '@src/catalogs/learner-list/data/hooks';
-import { useParams } from 'wouter';
 import { getCatalogInvitations, resendInvitation, cancelInvitation } from './api';
 
 export const queryKey = {
@@ -54,7 +52,6 @@ export const useResendInvitation = () => {
 
 export const useCancelInvitation = () => {
   const queryClient = useQueryClient();
-  const { catalogSlug } = useParams<{ catalogSlug: string }>();
 
   return useMutation({
     mutationFn: async ({ catalogId, invitationId }: { catalogId: string; invitationId: number }) => (
@@ -63,7 +60,6 @@ export const useCancelInvitation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKey.catalogInvitations() });
       queryClient.invalidateQueries({ queryKey: learnersQueryKey.catalogLearners() });
-      queryClient.invalidateQueries({ queryKey: catalogsQueryKey.catalogDetail(catalogSlug) });
     },
   });
 };

--- a/src/catalogs/invitation-list/data/hooks.ts
+++ b/src/catalogs/invitation-list/data/hooks.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { appId } from '@src/constants';
+import { queryKey as catalogsQueryKey } from '@src/catalogs/data/hooks';
+import { queryKey as learnersQueryKey } from '@src/catalogs/learner-list/data/hooks';
+import { useParams } from 'wouter';
+import { getCatalogInvitations, resendInvitation, cancelInvitation } from './api';
+
+export const queryKey = {
+  all: [appId, 'catalogs'],
+  catalogInvitations: () => [...queryKey.all, 'invitations'],
+  catalogInvitationsList: (
+    catalogId: string,
+    pageIndex?: number,
+    pageSize?: number,
+    ordering?: string,
+    search?: string,
+    status?: string,
+  ) => [
+    ...queryKey.catalogInvitations(), catalogId, pageIndex, pageSize, ordering, search, status,
+  ],
+};
+
+export const useCatalogInvitations = ({
+  catalogId,
+  pageIndex,
+  pageSize,
+  ordering,
+  search,
+  status,
+}: {
+  catalogId: string;
+  pageIndex: number;
+  pageSize: number;
+  ordering?: string;
+  search?: string;
+  status?: string;
+}) => useQuery({
+  queryKey: queryKey.catalogInvitationsList(catalogId, pageIndex, pageSize, ordering, search, status),
+  queryFn: () => getCatalogInvitations(catalogId, pageIndex, pageSize, ordering, search, status),
+});
+
+export const useResendInvitation = () => {
+  const queryClient = useQueryClient();
+  const { catalogSlug } = useParams<{ catalogSlug: string }>();
+
+  return useMutation({
+    mutationFn: async ({ catalogId, invitationId }: { catalogId: string; invitationId: number }) => (
+      resendInvitation(catalogId, invitationId)
+    ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKey.catalogInvitations() });
+    },
+  });
+};
+
+export const useCancelInvitation = () => {
+  const queryClient = useQueryClient();
+  const { catalogSlug } = useParams<{ catalogSlug: string }>();
+
+  return useMutation({
+    mutationFn: async ({ catalogId, invitationId }: { catalogId: string; invitationId: number }) => (
+      cancelInvitation(catalogId, invitationId)
+    ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKey.catalogInvitations() });
+      queryClient.invalidateQueries({ queryKey: learnersQueryKey.catalogLearners() });
+      queryClient.invalidateQueries({ queryKey: catalogsQueryKey.catalogDetail(catalogSlug) });
+    },
+  });
+};

--- a/src/catalogs/invitation-list/data/hooks.ts
+++ b/src/catalogs/invitation-list/data/hooks.ts
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { appId } from '@src/constants';
-import { queryKey as learnersQueryKey } from '@src/catalogs/learner-list/data/hooks';
 import { getCatalogInvitations, resendInvitation, cancelInvitation } from './api';
+
+const learnersQueryKeyBase = [appId, 'catalogs', 'learners'];
 
 export const queryKey = {
   all: [appId, 'catalogs'],
@@ -59,7 +60,7 @@ export const useCancelInvitation = () => {
     ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKey.catalogInvitations() });
-      queryClient.invalidateQueries({ queryKey: learnersQueryKey.catalogLearners() });
+      queryClient.invalidateQueries({ queryKey: learnersQueryKeyBase });
     },
   });
 };

--- a/src/catalogs/invitation-list/data/hooks.ts
+++ b/src/catalogs/invitation-list/data/hooks.ts
@@ -41,7 +41,6 @@ export const useCatalogInvitations = ({
 
 export const useResendInvitation = () => {
   const queryClient = useQueryClient();
-  const { catalogSlug } = useParams<{ catalogSlug: string }>();
 
   return useMutation({
     mutationFn: async ({ catalogId, invitationId }: { catalogId: string; invitationId: number }) => (

--- a/src/catalogs/invitation-list/index.ts
+++ b/src/catalogs/invitation-list/index.ts
@@ -1,0 +1,1 @@
+export { default as InvitationList } from './components/InvitationList';

--- a/src/catalogs/invitation-list/messages.ts
+++ b/src/catalogs/invitation-list/messages.ts
@@ -1,0 +1,126 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'corporate.catalog.table.header.action': {
+    id: 'corporate.catalog.table.header.action',
+    defaultMessage: 'Action',
+    description: 'Header for the action column',
+  },
+  'corporate.catalog.invitations.table.empty.content': {
+    id: 'corporate.catalog.invitations.table.empty.content',
+    defaultMessage: 'No invitations found',
+    description: 'Empty table content for the invitations table.',
+  },
+  'corporate.catalog.invitations.table.header.email': {
+    id: 'corporate.catalog.invitations.table.header.email',
+    defaultMessage: 'Email',
+    description: 'Header for the invite email column',
+  },
+  'corporate.catalog.invitations.table.header.name': {
+    id: 'corporate.catalog.invitations.table.header.name',
+    defaultMessage: 'Name',
+    description: 'Header for the invitee name column',
+  },
+  'corporate.catalog.invitations.table.header.status': {
+    id: 'corporate.catalog.invitations.table.header.status',
+    defaultMessage: 'Status',
+    description: 'Header for the invitation status column',
+  },
+  'corporate.catalog.invitations.table.header.invited.at': {
+    id: 'corporate.catalog.invitations.table.header.invited.at',
+    defaultMessage: 'Invited At',
+    description: 'Header for the invited at column',
+  },
+  'corporate.catalog.invitations.table.header.accepted.at': {
+    id: 'corporate.catalog.invitations.table.header.accepted.at',
+    defaultMessage: 'Accepted At',
+    description: 'Header for the accepted at column',
+  },
+  'corporate.catalog.invitations.table.header.cancelled.at': {
+    id: 'corporate.catalog.invitations.table.header.cancelled.at',
+    defaultMessage: 'Cancelled At',
+    description: 'Header for the cancelled at column',
+  },
+  'corporate.catalog.invitations.table.header.invited.by': {
+    id: 'corporate.catalog.invitations.table.header.invited.by',
+    defaultMessage: 'Invited By',
+    description: 'Header for the invited by column',
+  },
+  'corporate.catalog.invitations.not.registered': {
+    id: 'corporate.catalog.invitations.not.registered',
+    defaultMessage: 'Not registered yet',
+    description: 'Label for invitees who have not yet registered on the platform',
+  },
+  'corporate.catalog.invitations.filter.pending': {
+    id: 'corporate.catalog.invitations.filter.pending',
+    defaultMessage: 'Pending',
+    description: 'Filter option for pending invitations',
+  },
+  'corporate.catalog.invitations.filter.accepted': {
+    id: 'corporate.catalog.invitations.filter.accepted',
+    defaultMessage: 'Accepted',
+    description: 'Filter option for accepted invitations',
+  },
+  'corporate.catalog.invitations.filter.declined': {
+    id: 'corporate.catalog.invitations.filter.declined',
+    defaultMessage: 'Declined',
+    description: 'Filter option for declined invitations',
+  },
+  'corporate.catalog.invitations.filter.removed': {
+    id: 'corporate.catalog.invitations.filter.removed',
+    defaultMessage: 'Removed',
+    description: 'Filter option for removed invitations',
+  },
+  'corporate.catalog.invitations.filter.cancelled': {
+    id: 'corporate.catalog.invitations.filter.cancelled',
+    defaultMessage: 'Cancelled',
+    description: 'Filter option for cancelled invitations',
+  },
+  'corporate.catalog.invitations.action.resend': {
+    id: 'corporate.catalog.invitations.action.resend',
+    defaultMessage: 'Resend',
+    description: 'Tooltip for the resend invitation action',
+  },
+  'corporate.catalog.invitations.action.cancel': {
+    id: 'corporate.catalog.invitations.action.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Tooltip for the cancel invitation action',
+  },
+  'corporate.catalog.invitations.modal.cancel.title': {
+    id: 'corporate.catalog.invitations.modal.cancel.title',
+    defaultMessage: 'Cancel Invitation',
+    description: 'Title for the cancel invitation modal',
+  },
+  'corporate.catalog.invitations.modal.cancel.confirmation': {
+    id: 'corporate.catalog.invitations.modal.cancel.confirmation',
+    defaultMessage: 'You are about to cancel the invitation sent to {email}. The invitee will no longer be able to accept this invitation.',
+    description: 'Confirmation message for cancelling an invitation',
+  },
+  'corporate.catalog.invitations.modal.cancel.action': {
+    id: 'corporate.catalog.invitations.modal.cancel.action',
+    defaultMessage: 'Cancel Invitation',
+    description: 'Action button text for cancelling an invitation',
+  },
+  'corporate.catalog.invitations.modal.cancel.success': {
+    id: 'corporate.catalog.invitations.modal.cancel.success',
+    defaultMessage: 'Invitation cancelled successfully.',
+    description: 'Success notification when an invitation is cancelled',
+  },
+  'corporate.catalog.invitations.modal.cancel.error': {
+    id: 'corporate.catalog.invitations.modal.cancel.error',
+    defaultMessage: 'Failed to cancel invitation.',
+    description: 'Error notification when cancelling an invitation fails',
+  },
+  'corporate.catalog.invitations.resend.success': {
+    id: 'corporate.catalog.invitations.resend.success',
+    defaultMessage: 'Invitation resent successfully.',
+    description: 'Success notification when an invitation is resent',
+  },
+  'corporate.catalog.invitations.resend.error': {
+    id: 'corporate.catalog.invitations.resend.error',
+    defaultMessage: 'Failed to resend invitation.',
+    description: 'Error notification when resending an invitation fails',
+  },
+});
+
+export default messages;

--- a/src/catalogs/invite-learners/components/InviteTableAction.tsx
+++ b/src/catalogs/invite-learners/components/InviteTableAction.tsx
@@ -4,9 +4,8 @@ import { Button } from '@openedx/paragon';
 import { PersonAddAlt } from '@openedx/paragon/icons';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { CELERY_STATUS } from '@src/constants';
+import { appId, CELERY_STATUS } from '@src/constants';
 import { useNotification } from '@src/notification';
-import { queryKey as invitationsQueryKey } from '@src/catalogs/invitation-list/data/hooks';
 import { useBulkInviteTaskStatus } from '../data/hooks';
 import { groupInviteErrors } from '../utils';
 import InviteLearnersModal from './InviteLearnersModal';
@@ -49,7 +48,7 @@ const InviteLearnerAction = ({ catalogId }: { catalogId: string }) => {
           ),
           'success',
         );
-        queryClient.invalidateQueries({ queryKey: invitationsQueryKey.catalogInvitations() });
+        queryClient.invalidateQueries({ queryKey: [appId, 'catalogs', 'invitations'] });
       }
 
       if (duplicateErrors.length > 0) {

--- a/src/catalogs/invite-learners/components/InviteTableAction.tsx
+++ b/src/catalogs/invite-learners/components/InviteTableAction.tsx
@@ -78,7 +78,7 @@ const InviteLearnerAction = ({ catalogId }: { catalogId: string }) => {
 
       setInviteTaskId(null);
     }
-  }, [data, intl, showNotification]);
+  }, [data, intl, showNotification, queryClient]);
 
   return (
     <>

--- a/src/catalogs/invite-learners/components/InviteTableAction.tsx
+++ b/src/catalogs/invite-learners/components/InviteTableAction.tsx
@@ -2,9 +2,11 @@ import { useState, useEffect, useRef } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import { PersonAddAlt } from '@openedx/paragon/icons';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { CELERY_STATUS } from '@src/constants';
 import { useNotification } from '@src/notification';
+import { queryKey as invitationsQueryKey } from '@src/catalogs/invitation-list/data/hooks';
 import { useBulkInviteTaskStatus } from '../data/hooks';
 import { groupInviteErrors } from '../utils';
 import InviteLearnersModal from './InviteLearnersModal';
@@ -14,6 +16,7 @@ import messages from '../messages';
 const InviteLearnerAction = ({ catalogId }: { catalogId: string }) => {
   const intl = useIntl();
   const { showNotification } = useNotification();
+  const queryClient = useQueryClient();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [inviteTaskId, setInviteTaskId] = useState<string | null>(null);
@@ -46,6 +49,7 @@ const InviteLearnerAction = ({ catalogId }: { catalogId: string }) => {
           ),
           'success',
         );
+        queryClient.invalidateQueries({ queryKey: invitationsQueryKey.catalogInvitations() });
       }
 
       if (duplicateErrors.length > 0) {

--- a/src/catalogs/invite-learners/data/hooks.ts
+++ b/src/catalogs/invite-learners/data/hooks.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CatalogInviteResponse, CatalogBulkInviteResponse } from '@src/types';
-import { CELERY_STATUS } from '@src/constants';
-import { queryKey as invitationsQueryKey } from '@src/catalogs/invitation-list/data/hooks';
+import { appId, CELERY_STATUS } from '@src/constants';
 import {
   getBulkInviteTaskStatus,
   postBulkCatalogInviteLearners,
@@ -31,7 +30,7 @@ export const useInviteLearners = () => {
     onSuccess: (_data) => {
       const response = _data as CatalogInviteResponse;
       if (!('taskId' in response)) {
-        queryClient.invalidateQueries({ queryKey: invitationsQueryKey.catalogInvitations() });
+        queryClient.invalidateQueries({ queryKey: [appId, 'catalogs', 'invitations'] });
       }
     },
   });

--- a/src/catalogs/invite-learners/data/hooks.ts
+++ b/src/catalogs/invite-learners/data/hooks.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { CatalogInviteResponse, CatalogBulkInviteResponse } from '@src/types';
 import { CELERY_STATUS } from '@src/constants';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKey as invitationsQueryKey } from '@src/catalogs/invitation-list/data/hooks';
 import {
   getBulkInviteTaskStatus,
   postBulkCatalogInviteLearners,
@@ -15,16 +17,26 @@ type InvitePayload = {
 /**
  * Hook to invite learners to a catalog.
  */
-export const useInviteLearners = () => useMutation({
-  mutationFn: async (
-    { catalogId, data }: { catalogId: string; data: InvitePayload },
-  ): Promise<CatalogInviteResponse | CatalogBulkInviteResponse> => {
-    if (data.csvFile) {
-      return postBulkCatalogInviteLearners(catalogId, { csvFile: data.csvFile });
-    }
-    return postCatalogInviteLearners(catalogId, { inviteEmail: data.emails || [], catalogId });
-  },
-});
+export const useInviteLearners = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (
+      { catalogId, data }: { catalogId: string; data: InvitePayload },
+    ): Promise<CatalogInviteResponse | CatalogBulkInviteResponse> => {
+      if (data.csvFile) {
+        return postBulkCatalogInviteLearners(catalogId, { csvFile: data.csvFile });
+      }
+      return postCatalogInviteLearners(catalogId, { inviteEmail: data.emails || [], catalogId });
+    },
+    onSuccess: (_data, variables) => {
+      const response = _data as CatalogInviteResponse;
+      if (!('taskId' in response)) {
+        queryClient.invalidateQueries({ queryKey: invitationsQueryKey.catalogInvitations() });
+      }
+    },
+  });
+};
 
 export const useBulkInviteTaskStatus = (
   catalogId: string,

--- a/src/catalogs/invite-learners/data/hooks.ts
+++ b/src/catalogs/invite-learners/data/hooks.ts
@@ -1,7 +1,6 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CatalogInviteResponse, CatalogBulkInviteResponse } from '@src/types';
 import { CELERY_STATUS } from '@src/constants';
-import { useQueryClient } from '@tanstack/react-query';
 import { queryKey as invitationsQueryKey } from '@src/catalogs/invitation-list/data/hooks';
 import {
   getBulkInviteTaskStatus,
@@ -29,7 +28,7 @@ export const useInviteLearners = () => {
       }
       return postCatalogInviteLearners(catalogId, { inviteEmail: data.emails || [], catalogId });
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (_data) => {
       const response = _data as CatalogInviteResponse;
       if (!('taskId' in response)) {
         queryClient.invalidateQueries({ queryKey: invitationsQueryKey.catalogInvitations() });

--- a/src/catalogs/messages.ts
+++ b/src/catalogs/messages.ts
@@ -28,8 +28,23 @@ const messages = defineMessages({
   },
   'corporate.catalog.header.info.seats': {
     id: 'corporate.catalog.table.info.seats',
-    defaultMessage: 'Available Seats',
+    defaultMessage: 'Seats',
     description: 'Info for the number of available seats in the catalog',
+  },
+  'corporate.catalog.header.info.seats.accepted': {
+    id: 'corporate.catalog.table.info.seats.accepted',
+    defaultMessage: 'accepted',
+    description: 'Label for accepted seats count in the seat breakdown',
+  },
+  'corporate.catalog.header.info.seats.pending': {
+    id: 'corporate.catalog.table.info.seats.pending',
+    defaultMessage: 'pending',
+    description: 'Label for pending seats count in the seat breakdown',
+  },
+  'corporate.catalog.header.info.seats.free': {
+    id: 'corporate.catalog.table.info.seats.free',
+    defaultMessage: 'free',
+    description: 'Label for free seats count in the seat breakdown',
   },
   'corporate.catalog.header.info.learners': {
     id: 'corporate.catalog.header.info.learners',
@@ -50,6 +65,11 @@ const messages = defineMessages({
     id: 'corporate.courses.page.tab.enrollments',
     defaultMessage: 'Enrollments',
     description: 'Catalog detail page tab title for enrollments',
+  },
+  'corporate.catalog.detail.page.tab.invitations': {
+    id: 'corporate.courses.page.tab.invitations',
+    defaultMessage: 'Invitations',
+    description: 'Catalog detail page tab title for invitations',
   },
   'corporate.courses.page.tab.analytics': {
     id: 'corporate.courses.page.tab.analytics',

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -67,3 +67,22 @@ export const LearnerStatus = ({ row }) => {
     </Badge>
   );
 };
+
+const INVITATION_STATUS_VARIANTS: Record<string, string> = {
+  pending: 'warning',
+  accepted: 'success',
+  declined: 'danger',
+  removed: 'danger',
+  cancelled: 'light',
+};
+
+export const InvitationStatus = ({ row }) => {
+  const intl = useIntl();
+  const status: string = row.original.status || 'pending';
+  const variant = INVITATION_STATUS_VARIANTS[status] || 'secondary';
+  return (
+    <Badge variant={variant}>
+      {intl.formatMessage(messages[`table.invitation.status.${status}`] || messages['table.invitation.status.pending'])}
+    </Badge>
+  );
+};

--- a/src/components/Table/messages.ts
+++ b/src/components/Table/messages.ts
@@ -41,6 +41,31 @@ const messages = defineMessages({
     defaultMessage: 'Inactive',
     description: 'Inactive learner status',
   },
+  'table.invitation.status.pending': {
+    id: 'table.invitation.status.pending',
+    defaultMessage: 'Pending',
+    description: 'Pending invitation status',
+  },
+  'table.invitation.status.accepted': {
+    id: 'table.invitation.status.accepted',
+    defaultMessage: 'Accepted',
+    description: 'Accepted invitation status',
+  },
+  'table.invitation.status.declined': {
+    id: 'table.invitation.status.declined',
+    defaultMessage: 'Declined',
+    description: 'Declined invitation status',
+  },
+  'table.invitation.status.removed': {
+    id: 'table.invitation.status.removed',
+    defaultMessage: 'Removed',
+    description: 'Removed invitation status',
+  },
+  'table.invitation.status.cancelled': {
+    id: 'table.invitation.status.cancelled',
+    defaultMessage: 'Cancelled',
+    description: 'Cancelled invitation status',
+  },
 });
 
 export default messages;

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface CatalogStats {
   courses: number;
   totalLearners: number;
   activeLearners: number;
+  pendingInvitations: number;
 }
 
 export interface Catalog extends CatalogBase, CatalogStats {
@@ -111,6 +112,22 @@ export interface Invitation {
   acceptedAt: string | null;
   declinedAt: string | null;
   status: string;
+}
+
+export interface CatalogInvitation {
+  id: number;
+  inviteEmail: string;
+  status: 'pending' | 'accepted' | 'declined' | 'removed' | 'cancelled';
+  statusDisplay: string;
+  isRegistered: boolean;
+  username: string | null;
+  fullName: string | null;
+  invitedAt: string;
+  acceptedAt: string | null;
+  declinedAt: string | null;
+  cancelledAt: string | null;
+  removedAt: string | null;
+  invitedBy: string | null;
 }
 
 export interface InvitationError {


### PR DESCRIPTION
# Invitations tab — manager MFE

Depends on: backend PR [#71](https://github.com/fccn/openedx-corporate/pull/71) (`openedx-corporate`)

## Summary

Adds a dedicated **Invitations** tab to `CatalogDetailPage` so managers can see
every invitation that has been sent, regardless of whether it has been accepted.
The existing Learners tab is untouched. Alongside the new tab, the seat-usage
display in the catalog header is updated from a single remaining-seats count to a
three-way breakdown: **accepted · pending · free**.

---

## What changed

### `src/catalogs/invitation-list/` *(new folder)*

Mirrors the structure of `src/catalogs/learner-list/`.

| File | Purpose |
|---|---|
| `components/InvitationList.tsx` | `DataTable` with columns: email, name, status, invited at, accepted at, cancelled at, invited by, actions. Default filter: `pending`. Resend and Cancel actions enabled only for `pending` rows. |
| `components/InvitationCancelModal.tsx` | Confirmation modal for the cancel action. |
| `data/api.ts` | `getCatalogInvitations`, `resendInvitation`, `cancelInvitation` — all built on `getCorporateApi`. |
| `data/hooks.ts` | `useCatalogInvitations` query; `useResendInvitation` and `useCancelInvitation` mutations. Mutations invalidate invitations list, learners list, and catalog detail on success. |
| `messages.ts` | All translatable strings for the tab. |
| `index.ts` | Re-export. |

### `src/catalogs/invitation-list/components/InvitationList.test.tsx` *(new)*
### `src/catalogs/invitation-list/components/InvitationCancelModal.test.tsx` *(new)*

14 tests covering: rendering, "Not registered yet" display, status badges, default
pending filter, disabled actions for non-pending rows, empty state, cancel
confirmation flow, download button.

### `src/components/Table/Cells.tsx`

Added `InvitationStatus` badge renderer (`pending → warning`, `accepted → success`,
`declined → danger`, `removed → danger`, `cancelled → light`). Separate from
`LearnerStatus` so the Learners tab is untouched.

### `src/components/Table/messages.ts`

Added translated labels for the five invitation statuses.

### `src/catalogs/CatalogDetailPage.tsx`

- Imported `InvitationList` and added the **Invitations** tab after Learners.
- Replaced the single remaining-seats string with an accepted · pending · free
  breakdown driven by the new `pendingInvitations` field.

### `src/catalogs/messages.ts`

Added messages for the three seat labels and the Invitations tab title.

### `src/catalogs/invite-learners/data/hooks.ts`

`useInviteLearners` now invalidates `invitationsQueryKey.catalogInvitations()` on
success for single invites, so the new tab refreshes immediately after sending.

### `src/catalogs/invite-learners/components/InviteTableAction.tsx`

Invalidates the same query key when a bulk CSV upload task completes with created
rows.

### `src/types.ts`

Added `CatalogInvitation` interface and `pendingInvitations` field to `CatalogStats`.

---

## Notes

- No changes to the Learners tab. Removed learners stay there under "Inactive".
- No bulk Resend / Cancel — single-row actions only.
- `Expired` status is out of scope.
